### PR TITLE
Implement nlargest and nsmallest

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,6 +186,19 @@ Examples of constructing a heap::
   h = mutable_binary_minheap([1,4,3,2])
   h = mutable_binary_maxheap([1,4,3,2])    # create a mutable min/max heap from a vector
 
+---------------------
+Functions using heaps
+---------------------
+
+Heaps can be used to extract the largest or smallest elements of an array
+without sorting the entire array first::
+
+  nlargest(3, [0,21,-12,68,-25,14]) # => [68,21,14]
+  nsmallest(3, [0,21,-12,68,-25,14]) # => [-25,-12,0]
+
+``nlargest(n, a)`` is equivalent to ``sort(a, lt = >)[1:min(n, end)]``, and
+``nsmallest(n, a)`` is equivalent to ``sort(a, lt = <)[1:min(n, end)]``.
+
 -----------------------------
 OrderedDicts and OrderedSets
 -----------------------------

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.3-
 Compat
+Docile

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -26,7 +26,7 @@ module DataStructures
     export push!
 
     export AbstractHeap, compare, extract_all!
-    export BinaryHeap, binary_minheap, binary_maxheap
+    export BinaryHeap, binary_minheap, binary_maxheap, nlargest, nsmallest
     export MutableBinaryHeap, mutable_binary_minheap, mutable_binary_maxheap
 
     export OrderedDict, OrderedSet
@@ -43,6 +43,10 @@ module DataStructures
     export excludelast, tokens
     export orderobject, Lt
 
+
+    if VERSION < v"0.4.0-dev"
+        using Docile
+    end
 
     include("delegate.jl")
 

--- a/test/test_binheap.jl
+++ b/test/test_binheap.jl
@@ -94,3 +94,13 @@ push!(h, 2)
 
 @test pop!(h) == 2
 @test isequal(h.valtree, [7, 10])
+
+# Tests for nlargest and nsmallest
+ss = [100,103,-12,-109,67,4,65,-52,-97,-32,-24,114,-128,
+      102,-56,-17,-41,25,-30,-84,26,-84,48,49,-5,-38,28,
+      114,-54,96,-55,67,74,127,-61,124,11,-7,93,-51,110,
+      -106,-84,-90,-18,-12,-116,21,115,50]
+for n = -1:length(ss) + 1
+    @test sort(ss, lt = >)[1:min(n, end)] == nlargest(n, ss)
+    @test sort(ss, lt = <)[1:min(n, end)] == nsmallest(n, ss)
+end


### PR DESCRIPTION
Python's heapq module offers two convenient functions, [`nlargest` and `nsmallest`](https://docs.python.org/2/library/heapq.html#heapq.nlargest). This patch replicates part of that functionality (the `key` argument is missing − it should probably be a feature of the underlying heap). 

For performance reasons I added an `extract_all_rev!` method, but since `extract_all` wasn't documented in `README.md` I didn't document it either. I also added relevant tests in `test_binheap.jl`.

