### PR TITLE
Get coverage data generation back up for Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,8 @@ julia:
     - nightly
 notifications:
     email: false
+script:
+    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+    - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("DataStructures"); Pkg.test("DataStructures"; coverage=true)'
 after_success:
     - julia -e 'cd(Pkg.dir("DataStructures")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'


### PR DESCRIPTION
Perhaps better to update the default Travis script, but for now.