### PR TITLE
RFC: Update OrderedDict, OrderedSet constructors to take iterables (fixes #50, #64, #67)

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -5,7 +5,7 @@ module DataStructures
     import Base: length, isempty, start, next, done,
                  show, dump, empty!, getindex, setindex!, get, get!,
                  in, haskey, keys, merge, copy, cat,
-                 push!, pop!, shift!, unshift!,
+                 push!, pop!, shift!, unshift!, insert!,
                  union!, delete!, similar, sizehint,
                  isequal, hash,
                  map, reverse,
@@ -36,7 +36,7 @@ module DataStructures
     export LinkedList, Nil, Cons, nil, cons, head, tail, list, filter, cat,
            reverse
     export SortedDict, SDToken, SDSemiToken
-    export insert!, startof
+    export startof
     export pastendtoken, beforestarttoken
     export searchsortedafter
     export enumerate_ind, packcopy, packdeepcopy
@@ -67,10 +67,21 @@ module DataStructures
     import .Tokens: Token, IntSemiToken, semi, container, assemble
     import .Tokens: deref_key, deref_value, deref, status
     import .Tokens: advance, regress
+
     include("sortedDict.jl")
     export semi, container, assemble, status
     export deref_key, deref_value, deref, advance, regress
+
     @deprecate stack Stack
     @deprecate queue Queue
     @deprecate add! push!
+
+    @deprecate HashDict{K,V}(ks::AbstractArray{K}, vs::AbstractArray{V}) HashDict{K,V,Unordered}(ks,vs)
+    @deprecate HashDict(ks, vs) HashDict{Any,Any,Unordered}(ks, vs)
+
+    @deprecate OrderedDict(ks, vs) OrderedDict(zip(ks,vs))
+    @deprecate OrderedDict{K,V}(ks::AbstractArray{K}, vs::AbstractArray{V}) OrderedDict{K,V}(zip(ks,vs))
+    @deprecate OrderedDict{K,V}(::Type{K},::Type{V}) OrderedDict{K,V}()
+
+    @deprecate OrderedSet(a, b...) OrderedSet({a, b...})
 end

--- a/src/defaultdict.jl
+++ b/src/defaultdict.jl
@@ -56,8 +56,8 @@ DefaultDictBase{F,D<:Associative}(default::F, d::D) = ((K,V)=eltype(d); DefaultD
 
 # most functions are simply delegated to the wrapped dictionary
 @delegate DefaultDictBase.d [ sizehint, empty!, setindex!, get, haskey,
-                              getkey, pop!, delete!, start, done, next,
-                              isempty, length ]
+                             getkey, pop!, delete!, start, done, next,
+                             isempty, length ]
 
 similar{K,V,F}(d::DefaultDictBase{K,V,F}) = DefaultDictBase{K,V,F}(d.default)
 in{T<:DefaultDictBase}(key, v::Base.KeyIterator{T}) = key in keys(v.dict.d)
@@ -132,7 +132,7 @@ for (DefaultDict,O) in [(:DefaultDict, :Unordered), (:DefaultOrderedDict, :Order
         @delegate $DefaultDict.d [ sizehint, empty!, setindex!,
                                    getindex, get, get!, haskey,
                                    getkey, pop!, delete!, start, next,
-                                   done, next, isempty, length]
+                                   done, next, isempty, length ]
 
         similar{K,V,F}(d::$DefaultDict{K,V,F}) = $DefaultDict{K,V,F}(d.d.default)
         in{T<:$DefaultDict}(key, v::Base.KeyIterator{T}) = key in keys(v.dict.d.d)

--- a/src/disjoint_set.jl
+++ b/src/disjoint_set.jl
@@ -103,7 +103,7 @@ type DisjointSets{T}
     function DisjointSets(xs)    # xs must be iterable
         imap = Dict{T,Int}()
         n = length(xs)
-        sizehint!(imap, n)
+        sizehint(imap, n)
         id = 0
         for x in xs
             imap[x] = (id += 1)

--- a/src/hashdict.jl
+++ b/src/hashdict.jl
@@ -530,3 +530,13 @@ next(v::ValueIterator{HashDict}, i) = (v.dict.vals[i], skip_deleted(v.dict,i+1))
 
 next{K,V}(v::KeyIterator{HashDict{K,V,Ordered}}, i) = (v.dict.keys[v.dict.order[i]], skip_deleted(v.dict,i+1))
 next{K,V}(v::ValueIterator{HashDict{K,V,Ordered}}, i) = (v.dict.vals[v.dict.order[i]], skip_deleted(v.dict,i+1))
+
+if VERSION >= v"0.4.0-dev+980"
+    push!(t::HashDict, p::Pair) = setindex!(t, p.second, p.first)
+    push!(t::HashDict, p::Pair, q::Pair) = push!(push!(t, p), q)
+    push!(t::HashDict, p::Pair, q::Pair, r::Pair...) = push!(push!(push!(t, p), q), r...)
+end
+
+push!(d::HashDict, p) = setindex!(d, p[2], p[1])
+push!(d::HashDict, p, q) = push!(push!(d, p), q)
+push!(d::HashDict, p, q, r...) = push!(push!(push!(d, p), q), r...)

--- a/src/hashdict.jl
+++ b/src/hashdict.jl
@@ -23,6 +23,7 @@ type HashDict{K,V,O<:Union(Ordered,Unordered)} <: Associative{K,V}
         new(zeros(Uint8,n), Array(K,n), Array(V,n), Array(O,n), Array(O,0), 0, 0, identity)
     end
     if VERSION >= v"0.4.0-dev+980"
+        HashDict(p::Pair) = setindex!(HashDict{K,V,O}(), p.second, p.first)
         function HashDict(ps::Pair{K,V}...)
             h = HashDict{K,V,O}()
             sizehint(h, length(ps))
@@ -31,10 +32,11 @@ type HashDict{K,V,O<:Union(Ordered,Unordered)} <: Associative{K,V}
             end
             return h
         end
+        HashDict(p::Pair{K,V}) = invoke(HashDict, (Pair{K,V}...), p)
     end
     function HashDict(ks, vs)
         if VERSION >= v"0.4.0-dev+980"
-            Base.warn_once("HashDict(kv,vs) is deprecated, use HashDict(collect(zip(ks,vs))) instead")
+            Base.warn_once("HashDict(kv,vs) is deprecated, use HashDict(zip(ks,vs)) instead")
         end
         n = length(ks)
         h = HashDict{K,V,O}()
@@ -43,7 +45,7 @@ type HashDict{K,V,O<:Union(Ordered,Unordered)} <: Associative{K,V}
         end
         return h
     end
-    function HashDict(kv::AbstractArray{(K,V)})
+    function HashDict(kv)
         h = HashDict{K,V,O}()
         sizehint(h, length(kv))
         for (k,v) in kv
@@ -54,16 +56,27 @@ type HashDict{K,V,O<:Union(Ordered,Unordered)} <: Associative{K,V}
 end
 
 HashDict() = HashDict{Any,Any,Unordered}()
+HashDict(kv::()) = HashDict()
+HashDict(kv) = hash_dict_with_eltype(kv, eltype(kv))
 
-HashDict{K,V}(ks::AbstractArray{K}, vs::AbstractArray{V}) = HashDict{K,V,Unordered}(ks,vs)
-HashDict(ks, vs) = HashDict{Any,Any,Unordered}(ks, vs)
+hash_dict_with_eltype{K,V}(kv, ::Type{(K,V)}) = HashDict{K,V}(kv)
+hash_dict_with_eltype(kv, t) = HashDict{Any,Any}(kv)
+
 HashDict{K,V}(kv::AbstractArray{(K,V)}) = HashDict{K,V,Unordered}(kv)
 if VERSION >= v"0.4.0-dev+980"
     HashDict{K,V}(ps::Pair{K,V}...) = HashDict{K,V,Unordered}(ps...)
+    HashDict{K,V}(kv::(Pair{K,V}...,))           = HashDict{K,V}(kv)
+    HashDict{K}  (kv::(Pair{K}...,))             = HashDict{K,Any}(kv)
+    HashDict{V}  (kv::(Pair{TypeVar(:K),V}...,)) = HashDict{Any,V}(kv)
+    HashDict     (kv::(Pair...,))                = HashDict{Any,Any}(kv)
+
+    HashDict{K,V}(kv::AbstractArray{Pair{K,V}})  = HashDict{K,V}(kv)
+
+    hash_dict_with_eltype{K,V}(kv, ::Type{Pair{K,V}})    = HashDict{K,V}(kv)
 end
 
 # TODO: these could be more efficient
-HashDict{K,V,O}(d::HashDict{K,V,O}) = HashDict{K,V,O}(collect(kv))
+HashDict{K,V,O}(d::HashDict{K,V,O}) = HashDict{K,V,O}(collect(d))
 HashDict{K,V}(d::Associative{K,V}) = HashDict{K,V,Unordered}(collect(d))
 
 similar{K,V,O}(d::HashDict{K,V,O}) = HashDict{K,V,O}()

--- a/src/ordereddict.jl
+++ b/src/ordereddict.jl
@@ -1,7 +1,7 @@
 # ordered dict
 
 import Base: haskey, get, get!, getkey, delete!, push!, pop!, empty!,
-             setindex!, getindex, sizehint, length, isempty, start,
+             setindex!, getindex, length, isempty, start,
              next, done, keys, values, setdiff, setdiff!,
              union, union!, intersect, isequal, filter, filter!,
              hash, eltype
@@ -51,10 +51,22 @@ copy(d::OrderedDict) = OrderedDict(d)
 
 ## Most functions are simply delegated to the wrapped HashDict
 
-@compat @delegate OrderedDict.d [ haskey, get, get!, getkey, delete!, pop!,
-                                 empty!, setindex!, getindex, sizehint,
-                                 length, isempty, start, next, done, keys,
-                                 values ]
+@delegate OrderedDict.d [ haskey, get, get!, getkey, delete!, pop!,
+                         empty!, setindex!, getindex,
+                         length, isempty, start, next, done, keys,
+                         values ]
+
+sizehint(d::OrderedDict, sz::Integer) = (sizehint(d.d, sz); d)
+
+if VERSION >= v"0.4.0-dev+980"
+    push!(d::OrderedDict, kv::Pair) = (push!(d.d, kv); d)
+    push!(d::OrderedDict, kv::Pair, kv2::Pair) = (push!(d.d, kv, kv2); d)
+    push!(d::OrderedDict, kv::Pair, kv2::Pair, kv3::Pair...) = (push!(d.d, kv, kv2, kv3...); d)
+end
+
+push!(d::OrderedDict, kv) = (push!(d.d, kv); d)
+push!(d::OrderedDict, kv, kv2...) = (push!(d.d, kv, kv2...); d)
+
 
 similar{K,V}(d::OrderedDict{K,V}) = OrderedDict{K,V}()
 in{T<:OrderedDict}(key, v::Base.KeyIterator{T}) = key in keys(v.dict.d.d)

--- a/src/ordereddict.jl
+++ b/src/ordereddict.jl
@@ -19,32 +19,42 @@ immutable OrderedDict{K,V} <: Associative{K,V}
     d::HashDict{K,V,Ordered}
 
     OrderedDict() = new(HashDict{K,V,Ordered}())
-    OrderedDict(kv::AbstractArray{(K,V)}) = new(HashDict{K,V,Ordered}(kv))
+    OrderedDict(kv) = new(HashDict{K,V,Ordered}(kv))
     if VERSION >= v"0.4.0-dev+980"
         OrderedDict(ps::Pair{K,V}...) = new(HashDict{K,V,Ordered}(ps...))
     end
-    OrderedDict(ks,vs) = new(HashDict{K,V,Ordered}(ks,vs))
+    #OrderedDict(ks,vs) = new(HashDict{K,V,Ordered}(ks,vs))
 end
 
 OrderedDict() = OrderedDict{Any,Any}()
+OrderedDict(kv::()) = OrderedDict()
+OrderedDict(kv) = ordered_dict_with_eltype(kv, eltype(kv))
 
-OrderedDict{K,V}(ks::AbstractArray{K}, vs::AbstractArray{V}) = OrderedDict{K,V}(ks,vs)
-OrderedDict{K,V}(::Type{K},::Type{V}) = OrderedDict{K,V}()
-OrderedDict(ks,vs) = OrderedDict{eltype(ks),eltype(vs)}(ks, vs)
+ordered_dict_with_eltype{K,V}(kv, ::Type{(K,V)}) = OrderedDict{K,V}(kv)
+ordered_dict_with_eltype(kv, t) = OrderedDict{Any,Any}(kv)
+
 if VERSION >= v"0.4.0-dev+980"
-    OrderedDict{K,V}(ps::Pair{K,V}...) = OrderedDict{K,V}(ps...)
+    OrderedDict{K,V}(ps::Pair{K,V}...)              = OrderedDict{K,V}(ps...)
+    OrderedDict{K,V}(kv::(Pair{K,V}...,))           = OrderedDict{K,V}(kv)
+    OrderedDict{K}  (kv::(Pair{K}...,))             = OrderedDict{K,Any}(kv)
+    OrderedDict{V}  (kv::(Pair{TypeVar(:K),V}...,)) = OrderedDict{Any,V}(kv)
+    OrderedDict     (kv::(Pair...,))                = OrderedDict{Any,Any}(kv)
+
+    OrderedDict{K,V}(kv::AbstractArray{Pair{K,V}})  = OrderedDict{K,V}(kv)
+
+    ordered_dict_with_eltype{K,V}(kv, ::Type{Pair{K,V}})    = OrderedDict{K,V}(kv)
 end
 
-OrderedDict{K,V}(kv::AbstractArray{(K,V)}) = OrderedDict{K,V}(kv)
+copy(d::OrderedDict) = OrderedDict(d)
 
 ## Functions
 
 ## Most functions are simply delegated to the wrapped HashDict
 
-@delegate OrderedDict.d [ haskey, get, get!, getkey, delete!, pop!,
-                          empty!, setindex!, getindex, sizehint,
-                          length, isempty, start, next, done, keys,
-                          values ]
+@compat @delegate OrderedDict.d [ haskey, get, get!, getkey, delete!, pop!,
+                                 empty!, setindex!, getindex, sizehint,
+                                 length, isempty, start, next, done, keys,
+                                 values ]
 
 similar{K,V}(d::OrderedDict{K,V}) = OrderedDict{K,V}()
 in{T<:OrderedDict}(key, v::Base.KeyIterator{T}) = key in keys(v.dict.d.d)

--- a/src/orderedset.jl
+++ b/src/orderedset.jl
@@ -9,16 +9,17 @@ immutable OrderedSet{T}
     dict::HashDict{T,Nothing,Ordered}
 
     OrderedSet() = new(HashDict{T,Nothing,Ordered}())
-    OrderedSet(x...) = union!(new(HashDict{T,Nothing,Ordered}()), x)
+    OrderedSet(xs) = union!(new(HashDict{T,Nothing,Ordered}()), xs)
 end
 OrderedSet() = OrderedSet{Any}()
-OrderedSet(x...) = OrderedSet{Any}(x...)
-OrderedSet{T}(x::T...) = OrderedSet{T}(x...)
+OrderedSet(xs) = OrderedSet{eltype(xs)}(xs)
 
-show(io::IO, s::OrderedSet) = (show(io, typeof(s)); Base.show_comma_array(io, s,'(',')'))
 
-@delegate OrderedSet.dict [isempty, length, sizehint]
+show(io::IO, s::OrderedSet) = (show(io, typeof(s)); print(io, "("); !isempty(s) && Base.show_vector(io, s,'[',']'); print(io, ")"))
 
+@delegate OrderedSet.dict [isempty, length]
+
+sizehint(s::OrderedSet, sz::Integer) = (sizehint(s.dict, sz); s)
 eltype{T}(s::OrderedSet{T}) = T
 
 in(x, s::OrderedSet) = haskey(s.dict, x)
@@ -43,7 +44,7 @@ done(s::OrderedSet, state) = done(s.dict, state)
 next(s::OrderedSet, i)     = (s.dict.keys[s.dict.order[i]], skip_deleted(s.dict,i+1))
 
 # TODO: simplify me?
-pop!(s::OrderedSet) = (val = s.dict.keys[start(s.dict)]; delete!(s.dict, val); val)
+pop!(s::OrderedSet) = (val = s.dict.keys[s.dict.order[start(s.dict)]]; delete!(s.dict, val); val)
 
 union(s::OrderedSet) = copy(s)
 function union(s::OrderedSet, sets...)

--- a/src/orderedset.jl
+++ b/src/orderedset.jl
@@ -15,7 +15,7 @@ OrderedSet() = OrderedSet{Any}()
 OrderedSet(xs) = OrderedSet{eltype(xs)}(xs)
 
 
-show(io::IO, s::OrderedSet) = (show(io, typeof(s)); print(io, "("); !isempty(s) && Base.show_vector(io, s,'[',']'); print(io, ")"))
+show(io::IO, s::OrderedSet) = (show(io, typeof(s)); print(io, "("); !isempty(s) && Base.show_comma_array(io, s,'[',']'); print(io, ")"))
 
 @delegate OrderedSet.dict [isempty, length]
 

--- a/test/test_ordereddict.jl
+++ b/test/test_ordereddict.jl
@@ -7,9 +7,9 @@ using Base.Test
 @test typeof(OrderedDict([(1,2.0)])) == OrderedDict{Int,Float64}
 @test typeof(OrderedDict([("a",1),("b",2)])) == OrderedDict{ASCIIString,Int}
 if VERSION >= v"0.4.0-dev+980"
-    @test typeof(OrderedDict(1 => 1.0)) == OrderedDict{Int,Float64}
-    @test typeof(OrderedDict(1 => 1.0, 2 => 2.0)) == OrderedDict{Int,Float64}
-    @test typeof(OrderedDict(1 => 1.0, 2 => 2.0, 3 => 3.0)) == OrderedDict{Int,Float64}
+    @test typeof(OrderedDict(Pair(1, 1.0))) == OrderedDict{Int,Float64}
+    @test typeof(OrderedDict(Pair(1, 1.0), Pair(2, 2.0))) == OrderedDict{Int,Float64}
+    @test typeof(OrderedDict(Pair(1, 1.0), Pair(2, 2.0), Pair(3, 3.0))) == OrderedDict{Int,Float64}
 end
 
 # empty dictionary
@@ -57,3 +57,246 @@ end
 od60[14]=15
 
 @test od60[14] == 15
+
+
+##############################
+# Copied and modified from Base/test/dict.jl
+
+# OrderedDict
+h = OrderedDict()
+for i=1:10000
+    h[i] = i+1
+end
+@test collect(h) == collect(zip(1:10000, 2:10001))
+
+for i=1:2:10000
+    delete!(h, i)
+end
+for i=1:2:10000
+    h[i] = i+1
+end
+
+for i=1:10000
+    @test h[i]==i+1
+end
+
+for i=1:10000
+    delete!(h, i)
+end
+@test isempty(h)
+
+h[77] = 100
+@test h[77]==100
+
+for i=1:10000
+    h[i] = i+1
+end
+
+for i=1:2:10000
+    delete!(h, i)
+end
+
+for i=10001:20000
+    h[i] = i+1
+end
+
+for i=2:2:10000
+    @test h[i]==i+1
+end
+
+for i=10000:20000
+    @test h[i]==i+1
+end
+
+h = OrderedDict{Any,Any}([("a", 3)])
+@test h["a"] == 3
+h["a","b"] = 4
+@test h["a","b"] == h[("a","b")] == 4
+h["a","b","c"] = 4
+@test h["a","b","c"] == h[("a","b","c")] == 4
+
+let
+    z = OrderedDict()
+    get_KeyError = false
+    try
+        z["a"]
+    catch _e123_
+        get_KeyError = isa(_e123_,KeyError)
+    end
+    @test get_KeyError
+end
+
+_d = OrderedDict([("a", 0)])
+@test isa([k for k in filter(x->length(x)==1, collect(keys(_d)))], Vector{Any})
+
+let
+    ## TODO: this should work, but inference seems to be working incorrectly
+    #d = OrderedDict(((1, 2), (3, 4)))
+    d = OrderedDict([(1, 2), (3, 4)])
+    @test d[1] === 2
+    @test d[3] === 4
+    ## TODO: @compat only rewrites Dict, not OrderedDict
+    # d2 = OrderedDict(1 => 2, 3 => 4)
+    # d3 = OrderedDict((1 => 2, 3 => 4))
+    # @test d == d2 == d3
+    # @test typeof(d) == typeof(d2) == typeof(d3) == OrderedDict{Int,Int}
+    @test typeof(d) == OrderedDict{Int,Int}
+
+    #d = OrderedDict(((1, 2), (3, "b")))
+    d = OrderedDict([(1, 2), (3, "b")])
+    @test d[1] === 2
+    @test d[3] == "b"
+    # d2 = OrderedDict(1 => 2, 3 => "b")
+    # d3 = OrderedDict((1 => 2, 3 => "b"))
+    # @test d == d2 == d3
+    # @test typeof(d) == typeof(d2) == typeof(d3) == OrderedDict{Int,Any}
+    @test typeof(d) == OrderedDict{Int,Any}
+
+    #d = OrderedDict(((1, 2), ("a", 4)))
+    d = OrderedDict([(1, 2), ("a", 4)])
+    @test d[1] === 2
+    @test d["a"] === 4
+    # d2 = OrderedDict(1 => 2, "a" => 4)
+    # d3 = OrderedDict((1 => 2, "a" => 4))
+    # @test d == d2 == d3
+    # @test typeof(d) == typeof(d2) == typeof(d3) == OrderedDict{Any,Int}
+    @test typeof(d) == OrderedDict{Any,Int}
+
+    #d = OrderedDict(((1, 2), ("a", "b")))
+    d = OrderedDict([(1, 2), ("a", "b")])
+    @test d[1] === 2
+    @test d["a"] == "b"
+    # d2 = OrderedDict(1 => 2, "a" => "b")
+    # d3 = OrderedDict((1 => 2, "a" => "b"))
+    # @test d == d2 == d3
+    # @test typeof(d) == typeof(d2) == typeof(d3) == OrderedDict{Any,Any}
+    @test typeof(d) == OrderedDict{Any,Any}
+end
+
+# TODO: this is a BoundsError on v0.3, ArgumentError on v0.4
+#@test_throws ArgumentError first(OrderedDict())
+@test first(OrderedDict([(:f, 2)])) == (:f,2)
+
+# issue #1821
+let
+    d = OrderedDict{UTF8String, Vector{Int}}()
+    d["a"] = [1, 2]
+    @test_throws MethodError d["b"] = 1
+    @test isa(repr(d), AbstractString)  # check that printable without error
+end
+
+# issue #2344
+let
+    local bar
+    bestkey(d, key) = key
+    bestkey{K<:AbstractString,V}(d::Associative{K,V}, key) = string(key)
+    bar(x) = bestkey(x, :y)
+    @test bar(OrderedDict([(:x, [1,2,5])])) == :y
+    @test bar(OrderedDict([("x", [1,2,5])])) == "y"
+end
+
+
+@test  isequal(OrderedDict(), OrderedDict())
+@test  isequal(OrderedDict([(1, 1)]), OrderedDict([(1, 1)]))
+@test !isequal(OrderedDict([(1, 1)]), OrderedDict())
+@test !isequal(OrderedDict([(1, 1)]), OrderedDict([(1, 2)]))
+@test !isequal(OrderedDict([(1, 1)]), OrderedDict([(2, 1)]))
+
+# Generate some data to populate dicts to be compared
+data_in = [ (rand(1:1000), randstring(2)) for _ in 1:1001 ]
+
+# Populate the first dict
+d1 = OrderedDict{Int, AbstractString}()
+for (k,v) in data_in
+    d1[k] = v
+end
+data_in = collect(d1)
+# shuffle the data
+for i in 1:length(data_in)
+    j = rand(1:length(data_in))
+    data_in[i], data_in[j] = data_in[j], data_in[i]
+end
+# Inserting data in different (shuffled) order should result in
+# equivalent dict.
+d2 = OrderedDict{Int, AbstractString}()
+for (k,v) in data_in
+    d2[k] = v
+end
+
+@test  isequal(d1, d2)
+d3 = copy(d2)
+d4 = copy(d2)
+# Removing an item gives different dict
+delete!(d1, data_in[rand(1:length(data_in))][1])
+@test !isequal(d1, d2)
+# Changing a value gives different dict
+d3[data_in[rand(1:length(data_in))][1]] = randstring(3)
+!isequal(d1, d3)
+# Adding a pair gives different dict
+d4[1001] = randstring(3)
+@test !isequal(d1, d4)
+
+@test isequal(OrderedDict(), sizehint(OrderedDict(),96))
+
+# Here is what currently happens when dictionaries of different types
+# are compared. This is not necessarily desirable. These tests are
+# descriptive rather than proscriptive.
+@test !isequal(OrderedDict([(1, 2)]), OrderedDict([("dog", "bone")]))
+@test isequal(OrderedDict{Int,Int}(), OrderedDict{AbstractString,AbstractString}())
+
+# get! (get with default values assigned to the given location)
+
+## TODO: get! not implemented for OrderedDict
+# let f(x) = x^2, d = OrderedDict((8, 19))
+
+#     @test get!(d, 8, 5) == 19
+#     @test get!(d, 19, 2) == 2
+
+#     @test get!(d, 42) do  # d is updated with f(2)
+#         f(2)
+#     end == 4
+
+#     @test get!(d, 42) do  # d is not updated
+#         f(200)
+#     end == 4
+
+#     @test get(d, 13) do   # d is not updated
+#         f(4)
+#     end == 16
+
+#     @test d == OrderedDict((8, 19), (19, 2), (42, 4))
+# end
+
+
+# issue #5886
+d5886 = OrderedDict()
+for k5886 in 1:11
+   d5886[k5886] = 1
+end
+for k5886 in keys(d5886)
+   # undefined ref if not fixed
+   d5886[k5886] += 1
+end
+
+# issue #8877
+## TODO: merge not implemented for OrderedDict
+# let
+#     a = OrderedDict("foo"  => 0.0, "bar" => 42.0)
+#     b = OrderedDict("フー" => 17, "バー" => 4711)
+#     @test is(typeof(merge(a, b)), OrderedDict{UTF8String,Float64})
+# end
+
+# issue 9295
+let
+    d = OrderedDict()
+    @test is(push!(d, ('a', 1)), d)
+    @test d['a'] == 1
+    @test is(push!(d, ('b', 2), ('c', 3)), d)
+    @test d['b'] == 2
+    @test d['c'] == 3
+    @test is(push!(d, ('d', 4), ('e', 5), ('f', 6)), d)
+    @test d['d'] == 4
+    @test d['e'] == 5
+    @test d['f'] == 6
+    @test length(d) == 6
+end

--- a/test/test_ordereddict.jl
+++ b/test/test_ordereddict.jl
@@ -4,7 +4,7 @@ using Base.Test
 # construction
 
 @test typeof(OrderedDict()) == OrderedDict{Any,Any}
-@test typeof(OrderedDict(1,2.0)) == OrderedDict{Int,Float64}
+@test typeof(OrderedDict([(1,2.0)])) == OrderedDict{Int,Float64}
 @test typeof(OrderedDict([("a",1),("b",2)])) == OrderedDict{ASCIIString,Int}
 if VERSION >= v"0.4.0-dev+980"
     @test typeof(OrderedDict(1 => 1.0)) == OrderedDict{Int,Float64}
@@ -13,7 +13,7 @@ if VERSION >= v"0.4.0-dev+980"
 end
 
 # empty dictionary
-d = OrderedDict(Char, Int)
+d = OrderedDict{Char, Int}()
 @test length(d) == 0
 @test isempty(d)
 @test_throws KeyError d['c'] == 1

--- a/test/test_orderedset.jl
+++ b/test/test_orderedset.jl
@@ -3,9 +3,203 @@ using Base.Test
 
 # construction
 
-@test typeof(OrderedSet()) == OrderedSet{Any}
-@test typeof(OrderedSet(['a'])) == OrderedSet{Char}
-@test typeof(OrderedSet([1,2,3,4])) == OrderedSet{Int}
+@test is(typeof(OrderedSet()), OrderedSet{Any})
+@test is(typeof(OrderedSet([1,2,3])), OrderedSet{Int})
+@test is(typeof(OrderedSet{Int}([3])), OrderedSet{Int})
+data_in = (1, "banana", ())
+s = OrderedSet(data_in)
+data_out = collect(s)
+@test is(typeof(data_out), Array{Any,1})
+@test is(tuple(data_out...), data_in)
+@test is(tuple(data_in...), tuple(s...))
+@test length(data_out) == length(data_in)
+
+# hash
+s1 = OrderedSet{ASCIIString}(["bar", "foo"])
+s2 = OrderedSet{ASCIIString}(["foo", "bar"])
+s3 = OrderedSet{ASCIIString}(["baz"])
+@test hash(s1) != hash(s2)
+@test hash(s1) != hash(s3)
+
+
+# isequal
+@test  isequal(OrderedSet(), OrderedSet())
+@test !isequal(OrderedSet(), OrderedSet([1]))
+@test  isequal(OrderedSet{Any}(Any[1,2]), OrderedSet{Int}([1,2]))
+@test !isequal(OrderedSet{Any}(Any[1,2]), OrderedSet{Int}([1,2,3]))
+
+@test  isequal(OrderedSet{Int}(), OrderedSet{AbstractString}())
+@test !isequal(OrderedSet{Int}(), OrderedSet{AbstractString}([""]))
+@test !isequal(OrderedSet{AbstractString}(), OrderedSet{Int}([0]))
+@test !isequal(OrderedSet{Int}([1]), OrderedSet{AbstractString}())
+@test  isequal(OrderedSet{Any}([1,2,3]), OrderedSet{Int}([1,2,3]))
+@test  isequal(OrderedSet{Int}([1,2,3]), OrderedSet{Any}([1,2,3]))
+@test !isequal(OrderedSet{Any}([1,2,3]), OrderedSet{Int}([1,2,3,4]))
+@test !isequal(OrderedSet{Int}([1,2,3]), OrderedSet{Any}([1,2,3,4]))
+@test !isequal(OrderedSet{Any}([1,2,3,4]), OrderedSet{Int}([1,2,3]))
+@test !isequal(OrderedSet{Int}([1,2,3,4]), OrderedSet{Any}([1,2,3]))
+
+# eltype, similar
+s1 = similar(OrderedSet([1,"hello"]))
+@test isequal(s1, OrderedSet())
+@test is(eltype(s1), Any)
+s2 = similar(OrderedSet{Float32}([2.0f0,3.0f0,4.0f0]))
+@test isequal(s2, OrderedSet())
+@test is(eltype(s2), Float32)
+
+# show
+@test endswith(sprint(show, OrderedSet()), "OrderedSet{Any}()")
+@test endswith(sprint(show, OrderedSet(['a'])), "OrderedSet{Char}(['a'])")
+
+s = OrderedSet(); push!(s,1); push!(s,2); push!(s,3)
+@test !isempty(s)
+@test in(1,s)
+@test in(2,s)
+@test length(s) == 3
+push!(s,1); push!(s,2); push!(s,3)
+@test length(s) == 3
+@test pop!(s,1) == 1
+@test !in(1,s)
+@test in(2,s)
+@test length(s) == 2
+@test_throws KeyError pop!(s,1)
+@test pop!(s,1,:foo) == :foo
+@test length(delete!(s,2)) == 1
+@test !in(1,s)
+@test !in(2,s)
+@test pop!(s) == 3
+@test length(s) == 0
+@test isempty(s)
+
+# copy
+data_in = (1,2,9,8,4)
+s = OrderedSet(data_in)
+c = copy(s)
+@test isequal(s,c)
+v = pop!(s)
+@test !in(v,s)
+@test  in(v,c)
+push!(s,100)
+push!(c,200)
+@test !in(100,c)
+@test !in(200,s)
+
+# sizehint, empty
+s = OrderedSet([1])
+@test isequal(sizehint(s, 10), OrderedSet([1]))
+@test isequal(empty!(s), OrderedSet())
+# TODO: rehash
+
+# start, done, next
+for data_in in ((7,8,4,5),
+                ("hello", 23, 2.7, (), [], (1,8)))
+    s = OrderedSet(data_in)
+
+    s_new = OrderedSet()
+    for el in s
+        push!(s_new, el)
+    end
+    @test isequal(s, s_new)
+
+    t = tuple(s...)
+
+    @test is(t, data_in)
+    @test length(t) == length(s)
+    for (e,f) in zip(t,s)
+        @test is(e,f)
+    end
+end
+
+# union
+@test isequal(union(OrderedSet([1])),OrderedSet([1]))
+s = ∪(OrderedSet([1,2]), OrderedSet([3,4]))
+@test isequal(s, OrderedSet([1,2,3,4]))
+s = union(OrderedSet([5,6,7,8]), OrderedSet([7,8,9]))
+@test isequal(s, OrderedSet([5,6,7,8,9]))
+s = OrderedSet([1,3,5,7])
+union!(s,(2,3,4,5))
+# TODO: order is not the same, so isequal should return false...
+@test isequal(s,OrderedSet([1,2,3,4,5,7]))
+
+# intersect
+@test isequal(intersect(OrderedSet([1])),OrderedSet([1]))
+s = ∩(OrderedSet([1,2]), OrderedSet([3,4]))
+@test isequal(s, OrderedSet())
+s = intersect(OrderedSet([5,6,7,8]), OrderedSet([7,8,9]))
+@test isequal(s, OrderedSet([7,8]))
+@test isequal(intersect(OrderedSet([2,3,1]), OrderedSet([4,2,3]), OrderedSet([5,4,3,2])), OrderedSet([2,3]))
+
+# setdiff
+@test isequal(setdiff(OrderedSet([1,2,3]), OrderedSet()),        OrderedSet([1,2,3]))
+@test isequal(setdiff(OrderedSet([1,2,3]), OrderedSet([1])),     OrderedSet([2,3]))
+@test isequal(setdiff(OrderedSet([1,2,3]), OrderedSet([1,2])),   OrderedSet([3]))
+@test isequal(setdiff(OrderedSet([1,2,3]), OrderedSet([1,2,3])), OrderedSet())
+@test isequal(setdiff(OrderedSet([1,2,3]), OrderedSet([4])),     OrderedSet([1,2,3]))
+@test isequal(setdiff(OrderedSet([1,2,3]), OrderedSet([4,1])),   OrderedSet([2,3]))
+s = OrderedSet([1,3,5,7])
+setdiff!(s,(3,5))
+@test isequal(s,OrderedSet([1,7]))
+s = OrderedSet([1,2,3,4])
+setdiff!(s, OrderedSet([2,4,5,6]))
+@test isequal(s,OrderedSet([1,3]))
+
+# ordering
+@test OrderedSet() < OrderedSet([1])
+@test OrderedSet([1]) < OrderedSet([1,2])
+@test !(OrderedSet([3]) < OrderedSet([1,2]))
+@test !(OrderedSet([3]) > OrderedSet([1,2]))
+@test OrderedSet([1,2,3]) > OrderedSet([1,2])
+@test !(OrderedSet([3]) <= OrderedSet([1,2]))
+@test !(OrderedSet([3]) >= OrderedSet([1,2]))
+@test OrderedSet([1]) <= OrderedSet([1,2])
+@test OrderedSet([1,2]) <= OrderedSet([1,2])
+@test OrderedSet([1,2]) >= OrderedSet([1,2])
+@test OrderedSet([1,2,3]) >= OrderedSet([1,2])
+@test !(OrderedSet([1,2,3]) >= OrderedSet([1,2,4]))
+@test !(OrderedSet([1,2,3]) <= OrderedSet([1,2,4]))
+
+# issubset, symdiff
+for (l,r) in ((OrderedSet([1,2]),     OrderedSet([3,4])),
+              (OrderedSet([5,6,7,8]), OrderedSet([7,8,9])),
+              (OrderedSet([1,2]),     OrderedSet([3,4])),
+              (OrderedSet([5,6,7,8]), OrderedSet([7,8,9])),
+              (OrderedSet([1,2,3]),   OrderedSet()),
+              (OrderedSet([1,2,3]),   OrderedSet([1])),
+              (OrderedSet([1,2,3]),   OrderedSet([1,2])),
+              (OrderedSet([1,2,3]),   OrderedSet([1,2,3])),
+              (OrderedSet([1,2,3]),   OrderedSet([4])),
+              (OrderedSet([1,2,3]),   OrderedSet([4,1])))
+    @test issubset(intersect(l,r), l)
+    @test issubset(intersect(l,r), r)
+    @test issubset(l, union(l,r))
+    @test issubset(r, union(l,r))
+    @test isequal(union(intersect(l,r),symdiff(l,r)), union(l,r))
+end
+@test ⊆(OrderedSet([1]), OrderedSet([1,2]))
+
+## TODO: not implemented for OrderedSets
+#@test ⊊(OrderedSet([1]), OrderedSet([1,2]))
+#@test !⊊(OrderedSet([1]), OrderedSet([1]))
+#@test ⊈(OrderedSet([1]), OrderedSet([2]))
+
+# TODO: returns false!
+#       == is not properly defined for OrderedSets
+#@test symdiff(OrderedSet([1,2,3,4]), OrderedSet([2,4,5,6])) == OrderedSet([1,3,5,6])
+@test isequal(symdiff(OrderedSet([1,2,3,4]), OrderedSet([2,4,5,6])), OrderedSet([1,3,5,6]))
+
+# filter
+s = OrderedSet([1,2,3,4])
+@test isequal(filter(isodd,s), OrderedSet([1,3]))
+filter!(isodd, s)
+@test isequal(s, OrderedSet([1,3]))
+
+# first
+# TODO: throws BoundsError in v0.3, ArgumentError in v0.4
+#@test_throws ArgumentError first(OrderedSet())
+@test first(OrderedSet(2)) == 2
+
+#####################
+
 
 # empty set
 d = OrderedSet{Char}()

--- a/test/test_orderedset.jl
+++ b/test/test_orderedset.jl
@@ -4,8 +4,8 @@ using Base.Test
 # construction
 
 @test typeof(OrderedSet()) == OrderedSet{Any}
-@test typeof(OrderedSet('a')) == OrderedSet{Char}
-@test typeof(OrderedSet(1,2,3,4)) == OrderedSet{Int}
+@test typeof(OrderedSet(['a'])) == OrderedSet{Char}
+@test typeof(OrderedSet([1,2,3,4])) == OrderedSet{Int}
 
 # empty set
 d = OrderedSet{Char}()


### PR DESCRIPTION
* Plus minor related changes

Eventually, these data structures might be made moot, if https://github.com/JuliaLang/julia/pull/10116 is merged.  But for now, it would at least be worthwhile matching `Dict` and `Set` construction in base in Julia v0.3.

I plan to merge this in a day or two, pending any comments.