### PR TITLE
Fix deprecations in tests

### DIFF
--- a/test/test_orderedset.jl
+++ b/test/test_orderedset.jl
@@ -194,8 +194,12 @@ filter!(isodd, s)
 @test isequal(s, OrderedSet([1,3]))
 
 # first
-# TODO: throws BoundsError in v0.3, ArgumentError in v0.4
-#@test_throws ArgumentError first(OrderedSet())
+if VERSION < v"0.4.0"
+    @test_throws BoundsError first(OrderedSet())
+else
+    @test_throws ArgumentError first(OrderedSet())
+end
+
 @test first(OrderedSet(2)) == 2
 
 #####################


### PR DESCRIPTION
Fixes a deprecation warning in one of the tests:

    OrderedSet(2)

is deprecated.

Also fix a TODO item for a disabled test.