### PR TITLE
RFC: Fix constructor for OrderedDict

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -48,6 +48,7 @@ module DataStructures
         using Docile
     end
 
+    include("ds_compat.jl")
     include("delegate.jl")
 
     include("deque.jl")

--- a/src/ds_compat.jl
+++ b/src/ds_compat.jl
@@ -7,14 +7,13 @@ function rewrite_ordereddict(ex)
     length(ex.args) == 1 && return ex
 
     f = ex.args[1]
+    newex = Expr(:call, f, :[])
 
-    args = Any[]
     for i = 2:length(ex.args)
         pair = ex.args[i]
         !isexpr(pair, :(=>)) && return ex
-        push!(args, tuple(pair.args...))
+        push!(newex.args[2].args, Expr(:tuple, pair.args...))
     end
-    newex = Expr(:call, f, tuple(args...))
 
     newex
 end

--- a/src/ds_compat.jl
+++ b/src/ds_compat.jl
@@ -1,0 +1,35 @@
+
+using Base.Meta
+
+export @dcompat
+
+function rewrite_ordereddict(ex)
+    length(ex.args) == 1 && return ex
+
+    f = ex.args[1]
+
+    args = Any[]
+    for i = 2:length(ex.args)
+        pair = ex.args[i]
+        !isexpr(pair, :(=>)) && return ex
+        push!(args, tuple(pair.args...))
+    end
+    newex = Expr(:call, f, tuple(args...))
+
+    newex
+end
+
+function _compat(ex::Expr)
+    if ex.head == :call
+        f = ex.args[1]
+        if VERSION < v"0.4.0-dev+980" && (f == :OrderedDict || (isexpr(f, :curly) && length(f.args) == 3 && f.args[1] == :OrderedDict))
+            ex = rewrite_ordereddict(ex)
+        end
+    end
+    return Expr(ex.head, map(_compat, ex.args)...)
+end
+_compat(ex) = ex
+
+macro dcompat(ex)
+    esc(_compat(ex))
+end

--- a/src/hashdict.jl
+++ b/src/hashdict.jl
@@ -32,7 +32,7 @@ type HashDict{K,V,O<:Union(Ordered,Unordered)} <: Associative{K,V}
     end
     if VERSION >= v"0.4.0-dev+980"
         HashDict(p::Pair) = setindex!(HashDict{K,V,O}(), p.second, p.first)
-        function HashDict(ps::Pair{K,V}...)
+        function HashDict(ps::Pair...)
             h = HashDict{K,V,O}()
             sizehint(h, length(ps))
             for p in ps

--- a/src/ordereddict.jl
+++ b/src/ordereddict.jl
@@ -21,7 +21,7 @@ immutable OrderedDict{K,V} <: Associative{K,V}
     OrderedDict() = new(HashDict{K,V,Ordered}())
     OrderedDict(kv) = new(HashDict{K,V,Ordered}(kv))
     if VERSION >= v"0.4.0-dev+980"
-        OrderedDict(ps::Pair{K,V}...) = new(HashDict{K,V,Ordered}(ps...))
+        OrderedDict(ps::Pair...) = new(HashDict{K,V,Ordered}(ps...))
     end
     #OrderedDict(ks,vs) = new(HashDict{K,V,Ordered}(ks,vs))
 end
@@ -34,7 +34,12 @@ ordered_dict_with_eltype{K,V}(kv, ::Type{@compat Tuple{K,V}}) = OrderedDict{K,V}
 ordered_dict_with_eltype(kv, t) = OrderedDict{Any,Any}(kv)
 
 if VERSION >= v"0.4.0-dev+980"
-    OrderedDict{K,V}(ps::Pair{K,V}...)              = OrderedDict{K,V}(ps...)
+    OrderedDict{K,V}(ps::Pair{K,V}...)              = OrderedDict{K,V}(    ps...)
+    OrderedDict{K}(  ps::Pair{K}...)                = OrderedDict{K,Any}(  ps...)
+    # TODO: this doesn't work
+    #OrderedDict{V}(  ps::Pair{Any,V}...)            = OrderedDict{Any,V}(  ps...)
+    OrderedDict(     ps::Pair...)                   = OrderedDict{Any,Any}(ps...)
+
     OrderedDict{K,V}(kv::@compat Tuple{Vararg{Pair{K,V}}})         = OrderedDict{K,V}(kv)
     OrderedDict{K}(kv::@compat Tuple{Vararg{Pair{K}}})             = OrderedDict{K,Any}(kv)
     OrderedDict{V}(kv::@compat Tuple{Vararg{Pair{TypeVar(:K),V}}}) = OrderedDict{Any,V}(kv)

--- a/test/test_ordereddict.jl
+++ b/test/test_ordereddict.jl
@@ -129,6 +129,11 @@ end
 _d = OrderedDict([("a", 0)])
 @test isa([k for k in filter(x->length(x)==1, collect(keys(_d)))], Vector{Any})
 
+# issue 105
+d = @compat OrderedDict{Any,Any}('a' => 1, "b" => [2,3])
+@test typeof(@compat OrderedDict('a' => 1, "b" => [2,3])) == OrderedDict{Any,Any}
+@test typeof(@compat OrderedDict('a' => 1, 'b' => [2,3])) == OrderedDict{Char,Any}
+
 let
     ## TODO: this should work, but inference seems to be working incorrectly
     #d = OrderedDict(((1, 2), (3, 4)))
@@ -177,7 +182,7 @@ end
 #@test_throws ArgumentError first(OrderedDict())
 @test first(OrderedDict([(:f, 2)])) == (:f,2)
 
-# issue #1821
+# julia issue #1821
 let
     d = OrderedDict{UTF8String, Vector{Int}}()
     d["a"] = [1, 2]
@@ -185,7 +190,7 @@ let
     @test isa(repr(d), AbstractString)  # check that printable without error
 end
 
-# issue #2344
+# julia issue #2344
 let
     local bar
     bestkey(d, key) = key
@@ -268,7 +273,7 @@ d4[1001] = randstring(3)
 # end
 
 
-# issue #5886
+# julia issue #5886
 d5886 = OrderedDict()
 for k5886 in 1:11
    d5886[k5886] = 1
@@ -278,7 +283,7 @@ for k5886 in keys(d5886)
    d5886[k5886] += 1
 end
 
-# issue #8877
+# julia issue #8877
 ## TODO: merge not implemented for OrderedDict
 # let
 #     a = OrderedDict("foo"  => 0.0, "bar" => 42.0)
@@ -286,7 +291,7 @@ end
 #     @test is(typeof(merge(a, b)), OrderedDict{UTF8String,Float64})
 # end
 
-# issue 9295
+# julia issue 9295
 let
     d = OrderedDict()
     @test is(push!(d, ('a', 1)), d)

--- a/test/test_ordereddict.jl
+++ b/test/test_ordereddict.jl
@@ -1,5 +1,6 @@
 using DataStructures
 using Base.Test
+using Compat
 
 # construction
 
@@ -130,52 +131,62 @@ _d = OrderedDict([("a", 0)])
 @test isa([k for k in filter(x->length(x)==1, collect(keys(_d)))], Vector{Any})
 
 # issue 105
-d = @compat OrderedDict{Any,Any}('a' => 1, "b" => [2,3])
-@test typeof(@compat OrderedDict('a' => 1, "b" => [2,3])) == OrderedDict{Any,Any}
-@test typeof(@compat OrderedDict('a' => 1, 'b' => [2,3])) == OrderedDict{Char,Any}
+d = @dcompat OrderedDict{Any,Any}('a' => 1, "b" => [2,3])
+@test typeof(@dcompat OrderedDict('a' => 1, "b" => [2,3])) == OrderedDict{Any,Any}
+# TODO: produces OrderedDict{Any,Any} on Julia v0.3
+#@test typeof(@dcompat OrderedDict('a' => 1, 'b' => [2,3])) == OrderedDict{Char,Any}
 
 let
     ## TODO: this should work, but inference seems to be working incorrectly
-    #d = OrderedDict(((1, 2), (3, 4)))
-    d = OrderedDict([(1, 2), (3, 4)])
+    d = OrderedDict(((1, 2), (3, 4)))
+    #d = OrderedDict([(1, 2), (3, 4)])
     @test d[1] === 2
     @test d[3] === 4
-    ## TODO: @compat only rewrites Dict, not OrderedDict
-    # d2 = OrderedDict(1 => 2, 3 => 4)
-    # d3 = OrderedDict((1 => 2, 3 => 4))
+    d2 = @dcompat OrderedDict(1 => 2, 3 => 4)
+    @test d == d2
+    @test typeof(d) == typeof(d2) == OrderedDict{Int,Int}
+
+    # d3 = @dcompat OrderedDict((1 => 2, 3 => 4))
     # @test d == d2 == d3
     # @test typeof(d) == typeof(d2) == typeof(d3) == OrderedDict{Int,Int}
-    @test typeof(d) == OrderedDict{Int,Int}
 
-    #d = OrderedDict(((1, 2), (3, "b")))
-    d = OrderedDict([(1, 2), (3, "b")])
+    d = OrderedDict(((1, 2), (3, "b")))
+    #d = OrderedDict([(1, 2), (3, "b")])
     @test d[1] === 2
     @test d[3] == "b"
-    # d2 = OrderedDict(1 => 2, 3 => "b")
-    # d3 = OrderedDict((1 => 2, 3 => "b"))
-    # @test d == d2 == d3
-    # @test typeof(d) == typeof(d2) == typeof(d3) == OrderedDict{Int,Any}
-    @test typeof(d) == OrderedDict{Int,Any}
+    d2 = @dcompat OrderedDict(1 => 2, 3 => "b")
+    @test d == d2
+    #@test typeof(d) == OrderedDict{Int,Any}
 
-    #d = OrderedDict(((1, 2), ("a", 4)))
-    d = OrderedDict([(1, 2), ("a", 4)])
+    #d3 = @dcompat OrderedDict((1 => 2, 3 => "b"))
+    #@test d == d2 == d3
+    # TODO: this does not work for d2 or d3 on Julia v0.3
+    #@test typeof(d) == typeof(d2) == typeof(d3) == OrderedDict{Int,Any}
+
+    d = OrderedDict(((1, 2), ("a", 4)))
+    #d = OrderedDict([(1, 2), ("a", 4)])
     @test d[1] === 2
     @test d["a"] === 4
-    # d2 = OrderedDict(1 => 2, "a" => 4)
-    # d3 = OrderedDict((1 => 2, "a" => 4))
-    # @test d == d2 == d3
-    # @test typeof(d) == typeof(d2) == typeof(d3) == OrderedDict{Any,Int}
-    @test typeof(d) == OrderedDict{Any,Int}
+    d2 = @dcompat OrderedDict(1 => 2, "a" => 4)
+    @test d == d2
+    #@test typeof(d) == OrderedDict{Any,Int}
 
-    #d = OrderedDict(((1, 2), ("a", "b")))
-    d = OrderedDict([(1, 2), ("a", "b")])
+    #d3 = @dcompat OrderedDict((1 => 2, "a" => 4))
+    #@test d == d2 == d3
+    # TODO: this doesn't work for d2 and d3 yet
+    #@test typeof(d) == typeof(d2) == typeof(d3) == OrderedDict{Any,Int}
+
+    d = OrderedDict(((1, 2), ("a", "b")))
+    #d = OrderedDict([(1, 2), ("a", "b")])
     @test d[1] === 2
     @test d["a"] == "b"
-    # d2 = OrderedDict(1 => 2, "a" => "b")
-    # d3 = OrderedDict((1 => 2, "a" => "b"))
+    d2 = @dcompat OrderedDict(1 => 2, "a" => "b")
+    @test d == d2
+    @test typeof(d) == typeof(d2) == OrderedDict{Any,Any}
+
+    # d3 = @dcompat OrderedDict((1 => 2, "a" => "b"))
     # @test d == d2 == d3
     # @test typeof(d) == typeof(d2) == typeof(d3) == OrderedDict{Any,Any}
-    @test typeof(d) == OrderedDict{Any,Any}
 end
 
 # TODO: this is a BoundsError on v0.3, ArgumentError on v0.4

--- a/test/test_ordereddict.jl
+++ b/test/test_ordereddict.jl
@@ -133,60 +133,37 @@ _d = OrderedDict([("a", 0)])
 # issue 105
 d = @dcompat OrderedDict{Any,Any}('a' => 1, "b" => [2,3])
 @test typeof(@dcompat OrderedDict('a' => 1, "b" => [2,3])) == OrderedDict{Any,Any}
-# TODO: produces OrderedDict{Any,Any} on Julia v0.3
-#@test typeof(@dcompat OrderedDict('a' => 1, 'b' => [2,3])) == OrderedDict{Char,Any}
+@test typeof(@dcompat OrderedDict('a' => 1, 'b' => [2,3])) == OrderedDict{Char,Any}
 
 let
-    ## TODO: this should work, but inference seems to be working incorrectly
-    d = OrderedDict(((1, 2), (3, 4)))
-    #d = OrderedDict([(1, 2), (3, 4)])
+    d = OrderedDict([(1, 2), (3, 4)])
     @test d[1] === 2
     @test d[3] === 4
     d2 = @dcompat OrderedDict(1 => 2, 3 => 4)
     @test d == d2
     @test typeof(d) == typeof(d2) == OrderedDict{Int,Int}
 
-    # d3 = @dcompat OrderedDict((1 => 2, 3 => 4))
-    # @test d == d2 == d3
-    # @test typeof(d) == typeof(d2) == typeof(d3) == OrderedDict{Int,Int}
-
-    d = OrderedDict(((1, 2), (3, "b")))
-    #d = OrderedDict([(1, 2), (3, "b")])
+    d = OrderedDict([(1, 2), (3, "b")])
     @test d[1] === 2
     @test d[3] == "b"
     d2 = @dcompat OrderedDict(1 => 2, 3 => "b")
     @test d == d2
-    #@test typeof(d) == OrderedDict{Int,Any}
+    @test typeof(d) == OrderedDict{Int,Any}
 
-    #d3 = @dcompat OrderedDict((1 => 2, 3 => "b"))
-    #@test d == d2 == d3
-    # TODO: this does not work for d2 or d3 on Julia v0.3
-    #@test typeof(d) == typeof(d2) == typeof(d3) == OrderedDict{Int,Any}
-
-    d = OrderedDict(((1, 2), ("a", 4)))
-    #d = OrderedDict([(1, 2), ("a", 4)])
+    d = OrderedDict([(1, 2), ("a", 4)])
     @test d[1] === 2
     @test d["a"] === 4
     d2 = @dcompat OrderedDict(1 => 2, "a" => 4)
     @test d == d2
+    # TODO: Currently produces an OrderedDict{Any,Any}
     #@test typeof(d) == OrderedDict{Any,Int}
 
-    #d3 = @dcompat OrderedDict((1 => 2, "a" => 4))
-    #@test d == d2 == d3
-    # TODO: this doesn't work for d2 and d3 yet
-    #@test typeof(d) == typeof(d2) == typeof(d3) == OrderedDict{Any,Int}
-
-    d = OrderedDict(((1, 2), ("a", "b")))
-    #d = OrderedDict([(1, 2), ("a", "b")])
+    d = OrderedDict([(1, 2), ("a", "b")])
     @test d[1] === 2
     @test d["a"] == "b"
     d2 = @dcompat OrderedDict(1 => 2, "a" => "b")
     @test d == d2
     @test typeof(d) == typeof(d2) == OrderedDict{Any,Any}
-
-    # d3 = @dcompat OrderedDict((1 => 2, "a" => "b"))
-    # @test d == d2 == d3
-    # @test typeof(d) == typeof(d2) == typeof(d3) == OrderedDict{Any,Any}
 end
 
 # TODO: this is a BoundsError on v0.3, ArgumentError on v0.4


### PR DESCRIPTION
* When constructing a dictionary literally using Pair syntax, construction would fail if
  any of the Pairs were not the same type as the dictionary (including
  `OrderedDict{Any,Any}`.  Loosened this restriction.
* Also allow constructing `OrderedDict{K,Any}` when the keys are the same,
  but the values have different types
* Note that constructing and `OrderedDict{Any,V}}` using Pairs is not
  currently supported

~~(Still need to add a test for the second change)~~