### PR TITLE
Include missing eltype functions so that collect works properly

### DIFF
--- a/src/sortedDict.jl
+++ b/src/sortedDict.jl
@@ -231,6 +231,8 @@ immutable ExcludeLast{K, D, Ord <: Ordering}
     pastlast::Int
 end
 
+eltype(e::ExcludeLast) = eltype(e.m)
+
 
 ## This holds an object describing an include-last
 ## (i.e., colon operator) iteration.
@@ -240,6 +242,8 @@ immutable IncludeLast{K, D, Ord <: Ordering}
     first::Int
     last::Int
 end
+
+eltype(e::IncludeLast) = eltype(e.m)
 
 
 ## The basic iterations are either over the whole sorted dict, an
@@ -256,21 +260,54 @@ immutable SDKeyIteration{T <: SDIterableTypesBase}
     base::T
 end
 
+eltype{K,D,Ord <: Ordering}(s::SDKeyIteration{SortedDict{K,D,Ord}}) = K
+eltype{K,D,Ord <: Ordering}(s::SDKeyIteration{ExcludeLast{K,D,Ord}}) = K
+eltype{K,D,Ord <: Ordering}(s::SDKeyIteration{IncludeLast{K,D,Ord}}) = K
+
 immutable SDValIteration{T <: SDIterableTypesBase}
     base::T
 end
+
+eltype{K,D,Ord <: Ordering}(s::SDValIteration{SortedDict{K,D,Ord}}) = D
+eltype{K,D,Ord <: Ordering}(s::SDValIteration{ExcludeLast{K,D,Ord}}) = D
+eltype{K,D,Ord <: Ordering}(s::SDValIteration{IncludeLast{K,D,Ord}}) = D
 
 immutable SDTokenIteration{T <: SDIterableTypesBase}
     base::T
 end
 
+eltype{K,D,Ord <: Ordering}(s::SDTokenIteration{SortedDict{K,D,Ord}}) = 
+        @compat Tuple{SDToken{K,D,Ord}, Tuple{K, D}}
+eltype{K,D,Ord <: Ordering}(s::SDTokenIteration{ExcludeLast{K,D,Ord}}) = 
+        @compat Tuple{SDToken{K,D,Ord}, Tuple{K, D}}
+eltype{K,D,Ord <: Ordering}(s::SDTokenIteration{IncludeLast{K,D,Ord}}) = 
+        @compat Tuple{SDToken{K,D,Ord}, Tuple{K, D}}
+
+
 immutable SDTokenKeyIteration{T <: SDIterableTypesBase}
     base::T
 end
 
+eltype{K,D,Ord <: Ordering}(s::SDTokenKeyIteration{SortedDict{K,D,Ord}}) = 
+        @compat Tuple{SDToken{K,D,Ord}, K}
+eltype{K,D,Ord <: Ordering}(s::SDTokenKeyIteration{ExcludeLast{K,D,Ord}}) = 
+        @compat Tuple{SDToken{K,D,Ord}, K}
+eltype{K,D,Ord <: Ordering}(s::SDTokenKeyIteration{IncludeLast{K,D,Ord}}) = 
+        @compat Tuple{SDToken{K,D,Ord}, K}
+
+
 immutable SDTokenValIteration{T <: SDIterableTypesBase}
     base::T
 end
+
+eltype{K,D,Ord <: Ordering}(s::SDTokenValIteration{SortedDict{K,D,Ord}}) = 
+        @compat Tuple{SDToken{K,D,Ord}, D}
+eltype{K,D,Ord <: Ordering}(s::SDTokenValIteration{ExcludeLast{K,D,Ord}}) = 
+        @compat Tuple{SDToken{K,D,Ord}, D}
+eltype{K,D,Ord <: Ordering}(s::SDTokenValIteration{IncludeLast{K,D,Ord}}) = 
+        @compat Tuple{SDToken{K,D,Ord}, D}
+
+
 
 typealias SDCompoundIterable Union(SDKeyIteration,
                                    SDValIteration, SDTokenIteration,
@@ -399,7 +436,10 @@ function in{K,D,Ord <: Ordering}(pr::(@compat Tuple{Any,Any}), m::SortedDict{K,D
     return exactfound && isequal(m.bt.data[i].d,convert(D,pr[2]))
 end
 
-eltype{K,D,Ord <: Ordering}(m::SortedDict{K,D,Ord}) = (K,D)
+eltype{K,D,Ord <: Ordering}(m::SortedDict{K,D,Ord}) = @compat Tuple{K,D}
+eltype{K,D,Ord <: Ordering}(::Type{SortedDict{K,D,Ord}}) = @compat Tuple{K,D}
+keytype{K,D,Ord <: Ordering}(::SortedDict{K,D,Ord}) = K
+datatype{K,D,Ord <: Ordering}(::SortedDict{K,D,Ord}) = D
 
 orderobject(m::SortedDict) = m.bt.ord
 

--- a/test/test_sorteddict.jl
+++ b/test/test_sorteddict.jl
@@ -431,7 +431,7 @@ function test2()
     wwx = first(m1)
     @test wwx[1] == 2
     tpr = eltype(m1)
-    @test tpr[1] == Int && tpr[2] == Float64
+    @test tpr == @compat Tuple{Int,Float64}
     co = orderobject(m1)
     @test co == Forward
     @test haskey(m1, 71)
@@ -507,6 +507,8 @@ function test3{T}(z::T)
         m1[bitreverse(lUi)] = lUi
     end
     count = 0
+    @test eltype(tokens(startof(m1) : endof(m1))) == 
+         @compat Tuple{SDToken{T,T,ForwardOrdering}, Tuple{T, T}}
     for (tok,(k,v)) in tokens(startof(m1) : endof(m1))
         for (tok2,(k2,v2)) in tokens(excludelast(startof(m1), pastendtoken(m1)))
             if isless(tok,tok2)
@@ -558,12 +560,14 @@ function test3{T}(z::T)
     end
     @test sv == sv2
     count = 0
+    @test eltype(tokens(keys(m1))) == @compat Tuple{SDToken{T,T,ForwardOrdering}, T}
     for (t,k) in tokens(keys(m1))
         @test deref_key(t) == k
         count += 1
     end
     @test count == N
     count = 0
+    @test eltype(tokens(values(m1))) == @compat Tuple{SDToken{T,T,ForwardOrdering}, T}
     for (t,v) in tokens(values(m1))
         @test deref_value(t) == v
         count += 1
@@ -572,22 +576,26 @@ function test3{T}(z::T)
 
     pos1 = searchsortedfirst(m1, div(N,2))
     sk2 = zero1
+    @test eltype(keys(excludelast(startof(m1),pos1))) == T
     for k in keys(excludelast(startof(m1), pos1))
         sk2 += k
     end
     @test sk2 == skhalf
     sv2 = zero1
+    @test eltype(values(excludelast(startof(m1),pos1))) == T
     for v in values(excludelast(startof(m1), pos1))
         sv2 += v
     end
     @test sv2 == svhalf
     count = 0
+    @test eltype(excludelast(pastendtoken(m1), pastendtoken(m1))) == @compat Tuple{T,T}
     for (k,v) in excludelast(pastendtoken(m1), pastendtoken(m1))
         count += 1
     end
     @test count == 0
     count = 0
-    for (k,v) in startof(m1) :  beforestarttoken(m1)
+    @test eltype(startof(m1) : beforestarttoken(m1)) == @compat Tuple{T,T}
+    for (k,v) in startof(m1) : beforestarttoken(m1)
         count += 1
     end
     @test count == 0


### PR DESCRIPTION
Address issue #103 by including many new eltype declarations.  Also, fixed the existing eltype declaration to be compatible with 0.4.
