### PR TITLE
fix Pair usage for ordereddict

### DIFF
--- a/src/defaultdict.jl
+++ b/src/defaultdict.jl
@@ -136,7 +136,7 @@ for (DefaultDict,O) in [(:DefaultDict, :Unordered), (:DefaultOrderedDict, :Order
         @delegate $DefaultDict.d [ sizehint, empty!, setindex!,
                                    getindex, get, get!, haskey,
                                    getkey, pop!, delete!, start, next,
-                                   done, next, isempty, length ]
+                                   done, isempty, length ]
 
         similar{K,V,F}(d::$DefaultDict{K,V,F}) = $DefaultDict{K,V,F}(d.d.default)
         in{T<:$DefaultDict}(key, v::Base.KeyIterator{T}) = key in keys(v.dict.d.d)
@@ -179,7 +179,7 @@ end
 # @delegate DefaultSortedDict.d [ sizehint, empty!, setindex!,
 #                            getindex, get, get!, haskey,
 #                            getkey, pop!, delete!, start, next,
-#                            done, next, isempty, length]
+#                            done, isempty, length]
 
 # similar{K,V,F}(d::DefaultSortedDict{K,V,F}) = DefaultSortedDict{K,V,F}(d.d.default)
 # in{T<:DefaultSortedDict}(key, v::Base.KeyIterator{T}) = key in keys(v.dict.d.d)

--- a/src/hashdict.jl
+++ b/src/hashdict.jl
@@ -525,10 +525,19 @@ end
 
 start(t::HashDict) = skip_deleted(t, 1)
 done(t::HashDict, i) = done(t.vals, i)
-next(t::HashDict, i) = ((t.keys[i],t.vals[i]), skip_deleted(t,i+1))
+if VERSION >= v"0.4.0-dev+980"
+    next(t::HashDict, i) = (Pair(t.keys[i],t.vals[i]), skip_deleted(t,i+1))
+else
+    next(t::HashDict, i) = ((t.keys[i],t.vals[i]), skip_deleted(t,i+1))
+end
+
 
 done{K,V}(t::HashDict{K,V,Ordered}, i) = done(t.order, i)
-next{K,V}(t::HashDict{K,V,Ordered}, i) = ((t.keys[t.order[i]],t.vals[t.order[i]]), skip_deleted(t,i+1))
+if VERSION >= v"0.4.0-dev+980"
+    next{K,V}(t::HashDict{K,V,Ordered}, i) = (Pair(t.keys[t.order[i]],t.vals[t.order[i]]), skip_deleted(t,i+1))
+else
+    next{K,V}(t::HashDict{K,V,Ordered}, i) = ((t.keys[t.order[i]],t.vals[t.order[i]]), skip_deleted(t,i+1))
+end
 
 isempty(t::HashDict) = (t.count == 0)
 length(t::HashDict) = t.count

--- a/test/test_ordereddict.jl
+++ b/test/test_ordereddict.jl
@@ -38,7 +38,11 @@ end
 
 @test collect(keys(d)) == collect('b':'z')
 @test collect(values(d)) == collect(2:26)
-@test collect(d) == [(a,i) for (a,i) in zip('b':'z', 2:26)]
+if VERSION >= v"0.4.0-dev+980"
+    @test collect(d) == [Pair(a,i) for (a,i) in zip('b':'z', 2:26)]
+else
+    @test collect(d) == [(a,i) for (a,i) in zip('b':'z', 2:26)]
+end
 
 # Test for #60
 
@@ -63,11 +67,16 @@ od60[14]=15
 # Copied and modified from Base/test/dict.jl
 
 # OrderedDict
-h = OrderedDict()
+h = OrderedDict{Int,Int}()
 for i=1:10000
     h[i] = i+1
 end
-@test collect(h) == collect(zip(1:10000, 2:10001))
+
+if VERSION >= v"0.4.0-dev+980"
+    @test collect(h) == [Pair(x,y) for (x,y) in zip(1:10000, 2:10001)]
+else
+    @test collect(h) == collect(zip(1:10000, 2:10001))
+end
 
 for i=1:2:10000
     delete!(h, i)
@@ -175,7 +184,12 @@ end
 
 # TODO: this is a BoundsError on v0.3, ArgumentError on v0.4
 #@test_throws ArgumentError first(OrderedDict())
-@test first(OrderedDict([(:f, 2)])) == (:f,2)
+
+if VERSION >= v"0.4.0-dev+980"
+    @test first(OrderedDict([(:f, 2)])) == Pair(:f,2)
+else
+    @test first(OrderedDict([(:f, 2)])) == (:f,2)
+end
 
 # issue #1821
 let
@@ -206,7 +220,7 @@ end
 data_in = [ (rand(1:1000), randstring(2)) for _ in 1:1001 ]
 
 # Populate the first dict
-d1 = OrderedDict{Int, AbstractString}()
+d1 = OrderedDict{Int, ASCIIString}()
 for (k,v) in data_in
     d1[k] = v
 end


### PR DESCRIPTION
Make `collect` return an array of `Pair`s, fixes unit tests.
~~Fixed `IntSet` deprectation warning for `status()` of `SortedDict`.~~(not necessary after rebase)