### PR TITLE
For sorted containers: add more constructors; add new behavior for 'i…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -481,44 +481,119 @@ Constructors for Sorted Containers
 
 ``SortedDict(d)``
   Argument ``d`` is an ordinary Julia dict (or any associative type)
-  used to initialize the container, e.g.::
+  used to initialize the container, e.g., for Julia 0.4::
 
      c = SortedDict(Dict("New York" => 1788, "Illinois" => 1818))
 
+  or for 0.3::
+
+     c = SortedDict(["New York" => 1788, "Illinois" => 1818])
+
+
   In this example the key-type is deduced to be ASCIIString, while the
-  value-type is Int.
+  value-type is Int.  The default ordering object ``Forward`` is used.
+  See below for more information about ordering.
 
 ``SortedDict(d,o)``
   Argument ``d`` is an ordinary Julia dict (or any associative type)
-  used to initialize the container and ``o`` is an optional ordering object
-  used for ordering the keys.  The default value
-  for ``o`` is ``Forward``.
+  used to initialize the container and ``o`` is an ordering object
+  used for ordering the keys. 
 
-``SortedDict(Dict{K,V}(),o)``
-  Construct an empty SortedDict by explicitly specifying
-  the parameters of the type.  Ordering argument ``o`` is
-  optional and defaults to ``Forward``.
+``SortedDict(k1=>v1, k2=>v2, ...)``
+  Arguments are key-value pairs for insertion into the 
+  dictionary.  
+  The keys must be of the same type as one another; the
+  values must also be of one type.  (Julia 0.4 only.)
 
-``SortedMultiDict(k,v,o)``
-  Construct a SortedMultiDict using keys given by ``k``, values
-  given by ``v`` and ordering object ``o``.  The ordering object
+``SortedDict(o, k1=>v1, k2=>v2, ...)``
+  The first argument ``o`` is an ordering object.  The remaining
+  arguments are key-value pairs for insertion into the 
+  dictionary.  
+  The keys must be of the same type as one another; the
+  values must also be of one type. (Julia 0.4 only.)
+
+``SortedDict(iter)``
+  Takes an arbitrary iterable object of (key,value) pairs.
+  The default Forward ordering is used.  In Julia 0.3,
+  the ``iter`` argument must be an ``AbstractArray`` of
+  key-value pairs.
+
+``SortedDict(iter,o)``
+  Takes an arbitrary iterable object of (key,value) pairs.
+  The ordering object ``o`` is explicitly given.  In Julia 0.3,
+  the ``iter`` argument must be an ``AbstractArray`` of
+  key-value pairs.
+
+``SortedDict{K,V,Ord}(o)``
+  Construct an empty SortedDict in which type parameters
+  are explicitly listed; ordering object is explicitly specified.
+  (See below for discussion of ordering.)  An empty SortedDict
+  may also be constructed using ``SortedDict(Dict{K,V}(),o)`` 
+  in Julia 0.4, where the ``o`` argument is optional, or 
+  ``SortedDict((K=>V)[],o)`` in Julia 0.3.
+
+``SortedDict(ks,vs,o)``
+  Here, ``ks`` is an array of keys, ``vs`` is an array of values
+  of the same length, and ``o`` is the optional ordering argument.
+  This syntax is available in Julia 0.3 only.  In Julia 0.4,
+  use ``SortedDict(zip(ks,vs),o).``
+
+``SortedMultiDict(ks,vs,o)``
+  Construct a SortedMultiDict using keys given by ``ks``, values
+  given by ``vs`` and ordering object ``o``.  The ordering object
   defaults to ``Forward`` if not specified.  The two arguments
-  ``k`` and ``v`` are 1-dimensional arrays of the same length in 
-  which ``k`` holds keys and ``v`` holds the corresponding values.
-  To construct an empty SortedMultiDict with given types ``K`` and
-  ``V``, use
-  ``SortedMultiDict(K[], V[], o)``.
+  ``ks`` and ``vs`` are 1-dimensional arrays of the same length in 
+  which ``ks`` holds keys and ``vs`` holds the corresponding values.
 
-``SortedSet(k,o)``
-  Construct a SortedSet using keys given by ``k``,
+
+``SortedMultiDict(k1=>v1, k2=>v2, ...)``
+  Arguments are key-value pairs for insertion into the 
+  multidict.  
+  The keys must be of the same type as one another; the
+  values must also be of one type.  Julia 0.4 only.
+
+
+``SortedMultiDict(o, k1=>v1, k2=>v2, ...)``
+  The first argument ``o`` is an ordering object.  The remaining
+  arguments are key-value pairs for insertion into the 
+  multidict.
+  The keys must be of the same type as one another; the
+  values must also be of one type. Julia 0.4 only.
+
+
+``SortedMultiDict(iter)``
+  Takes an arbitrary iterable object of (key,value) pairs.
+  The default Forward ordering is used.  In Julia 0.3, 
+  the ``iter`` argument must be an ``AbstractArray.``
+
+``SortedMultiDict(iter,o)``
+  Takes an arbitrary iterable object of (key,value) pairs.
+  The ordering object ``o`` is explicitly given.
+  In Julia 0.3, 
+  the ``iter`` argument must be an ``AbstractArray.``
+
+
+``SortedMultiDict{K,V,Ord}(o)``
+  Construct an empty sorted multidict in which type parameters
+  are explicitly listed; ordering object is explicitly specified.
+  (See below for discussion of ordering.)  An empty SortedMultiDict
+  may also be constructed via ``SortedMultiDict(K[], V[], o)`` where
+  the ``o`` argument is optional.
+
+``SortedSet(iter,o)``
+  Construct a SortedSet using keys given by iterable ``iter`` (e.g.,
+  an array)
   and ordering object ``o``.  The ordering object
-  defaults to ``Forward`` if not specified.  The argument
-  ``k``is a 1-dimensional array.  To create an empty set of type ``K``,
-  use ``SortedSet(K[],o)``.
+  defaults to ``Forward`` if not specified.  
 
-Note that the code snippets in this section are based on the Julia
-version 0.4.0 Dict-constructor
-syntax.  There are equivalent statements for 0.3.0.
+``SortedSet{K,Ord}(o)``
+  Construct an empty sorted set in which type parameter
+  is explicitly listed; ordering object is explicitly specified.
+  (See below for discussion of ordering.)  An alternate way
+  to create an empty set of type ``K`` is ``SortedSet(K[], o)``;
+  again, the order argument defaults to ``Forward`` if not
+  specified.
+
 
 
 ---------------------------------
@@ -951,6 +1026,51 @@ Other Functions
   addresses a large number of values, and an alternative
   should be considered.)
 
+``in(x,iter)``
+  Returns true if ``x`` is in ``iter``, where
+  ``iter`` refers to any of the iterable objects described
+  above in the discussion of container loops and ``x``
+  is of the appropriate type.
+  For all of the iterables except the five listed below,
+  the algorithm used 
+  is a linear-time search.  For example, the call::
+     
+    (k,v) in exclusive(sd,st1,st2)
+
+  where ``sd`` is a SortedDict, ``st1`` and ``st2`` are
+  semitokens, ``k`` is a key, and ``v`` is a value, will
+  loop over all entries in the dictionary between
+  the two tokens and a compare for equality using ``isequal`` between the
+  indexed item and ``(k,v)``.  
+
+  The five exceptions are::
+
+       (k,v) in sd
+       (k,v) in smd
+       k in ss
+       k in keys(sd)
+       k in keys(smd)
+
+  These five invocations of ``in`` (where ``sd`` is a SortedDict,
+  ``smd`` is a SortedMultiDict, and ``ss`` is a SortedSet)
+  use the index structure
+  of the sorted container and test equality
+  based on the order object of the keys rather than ``isequal``.
+  Therefore, these five are all faster than linear-time looping.
+  The first three were already discussed in the previous entry.
+  The last two are equivalent to ``haskey(sd,k)`` and ``haskey(smd,k)``
+  respectively.  To force the use of ``isequal``
+  test on the keys rather than the order object (thus
+  slowing the execution from logarithmic to linear time), replace
+  the above five constructs with these::
+
+       (k,v) in collect(sd)
+       (k,v) in collect(smd)
+       k in collect(ss)
+       k in collect(keys(sd))
+       k in collect(keys(smd))
+
+
 ``eltype(sc)``
   Returns the (key,value) type (a 2-entry tuple)
   for SortedDict and SortedMultiDict.
@@ -958,13 +1078,19 @@ Other Functions
   also be applied to the type itself.
   Time: O(1)
 
+``similar(sc)``
+  Returns a new SortedDict, SortedMultiDict, or SortedSet 
+  of the same type and with the same ordering
+  as ``sc`` but with no entries (i.e., empty).  Time: O(1)
+
 ``orderobject(sc)``
   Returns the order object used to construct the container.  Time: O(1)
 
 ``haskey(sc,k)``
   Returns true if key ``k`` is present for SortedDict, SortedMultiDict
   or SortedSet ``sc``.  For SortedSet, ``haskey(sc,k)`` is
-  a synonym for ``in(k,sc)``.
+  a synonym for ``in(k,sc)``.  For SortedDict and SortedMultiDict,
+  ``haskey(sc,k)`` is equivalent to ``in(k,keys(sc))``.
   Time: O(*c* log *n*)
 
 
@@ -1134,8 +1260,10 @@ If it does not hold for a certain type, then a custom ordering
 argument must be defined as discussed in the next few paragraphs.
 
 The name for the default ordering (i.e., using ``isless`` and
-``isequal``) is ``Forward``.  Another possible
-choice is ``Reverse``, which reverses the usual sorted order.  
+``isequal``) is ``Forward``.  Note: this is the name of the
+ordering object; its type is ``ForwardOrdering.``
+Another possible
+ordering object is ``Reverse``, which reverses the usual sorted order.  
 This name must be
 imported ``import Base.Reverse`` if it is used.
 
@@ -1152,9 +1280,8 @@ In the above example, the ordering object would be::
 
      Lt((x,y) -> isless(lowercase(x),lowercase(y)))
 
-The ordering object is the second argument to
-the ``SortedDict`` and ``SortedSet``  constructors, or the
-third argument to the ``SortedMultiDict`` constructor 
+The ordering object is indicated in the above list of constructors
+in the ``o`` position
 (see above for constructor syntax).
 
 This approach suffers from a performance hit (10%-50% depending on the
@@ -1189,7 +1316,7 @@ be::
 
 Finally, the user specifies the unique element of ``CaseInsensitive``, namely
 the object ``CaseInsensitive()``, as the ordering object to the
-``SortedDict`` constructor.
+``SortedDict``, ``SortedMultiDict`` or ``SortedSet`` constructor.
 
 For the above code to work, the module must make the following declarations,
 typically near the beginning::

--- a/src/containerloops.jl
+++ b/src/containerloops.jl
@@ -5,7 +5,7 @@ import Base.values
 ## The prefix SDM is for SortedDict and SortedMultiDict
 ## The prefix SS is for SortedSet.  The prefix SA
 ## is for all sorted containers.  
-## These definitions now appear in tokens2.jl
+## The following two definitions now appear in tokens2.jl
 
 #typealias SDMContainer Union(SortedDict, SortedMultiDict)
 #typealias SAContainer Union(SDMContainer, SortedSet)
@@ -23,6 +23,8 @@ immutable SDMExcludeLast{ContainerType <: SDMContainer} <:
     first::Int
     pastlast::Int
 end
+
+
 
 immutable SSExcludeLast{ContainerType <: SortedSet} <: 
                               AbstractExcludeLast{ContainerType}
@@ -177,8 +179,18 @@ end
 
 
 # Next definition needed to break ambiguity with keys(Associative) from Dict.jl
+
 @inline keys{K, D, Ord <: Ordering}(ba::SortedDict{K,D,Ord}) = SDMKeyIteration(ba)
 @inline keys{T <: SDMIterableTypesBase}(ba::T) = SDMKeyIteration(ba)
+
+
+in{K,D,Ord <: Ordering}(k, keyit::SDMKeyIteration{SortedDict{K,D,Ord}}) =
+    haskey(extractcontainer(keyit.base), k)
+
+in{K,D,Ord <: Ordering}(k, keyit::SDMKeyIteration{SortedMultiDict{K,D,Ord}}) = 
+    haskey(extractcontainer(keyit.base), k)
+
+    
 
 # Next definition needed to break ambiguity with values(Associative) from Dict.jl
 @inline values{K, D, Ord <: Ordering}(ba::SortedDict{K,D,Ord}) = SDMValIteration(ba)

--- a/src/sortedSet.jl
+++ b/src/sortedSet.jl
@@ -4,6 +4,15 @@
 
 type SortedSet{K, Ord <: Ordering}
     bt::BalancedTree23{K,Nothing,Ord}
+
+## Zero-argument constructor, or possibly one argument to specify order.
+
+    function SortedSet(o::Ord=Forward)
+        bt1 = BalancedTree23{K,Nothing,Ord}(o)
+        new(bt1)
+    end
+
+
 end
 
 
@@ -12,16 +21,23 @@ typealias SetSemiToken IntSemiToken
 # The following definition was moved to tokens2.jl
 #typealias SetToken Tuple{SortedSet, IntSemiToken}
 
-## This constructor takes a set ordering object which defaults
+## This constructor takes an iterable; order defaults
 ## to Forward
 
-function SortedSet{K,Ord <: Ordering}(d::AbstractArray{K,1}, o::Ord=Forward)
-    bt1 = BalancedTree23{K, Nothing, Ord}(o)
-    for pr in d
-        insert!(bt1, pr, nothing, false)
+## This one takes an iterable; ordering type is optional.
+
+SortedSet{Ord <: Ordering}(iter, o::Ord=Forward) = 
+sortedset_with_eltype(iter, eltype(iter), o)
+
+function sortedset_with_eltype{K,Ord}(iter, ::Type{K}, o::Ord)
+    h = SortedSet{K,Ord}(o)
+    for k in iter
+        insert!(h, k)
     end
-    SortedSet(bt1)
+    h
 end
+
+
 
 ## This function looks up a key in the tree;
 ## if not found, then it returns a marker for the
@@ -77,6 +93,7 @@ end
 end
 
 @inline eltype{K,Ord <: Ordering}(m::SortedSet{K,Ord}) = K
+@inline eltype{K,Ord <: Ordering}(::Type{SortedSet{K,Ord}}) = K
 @inline keytype{K,Ord <: Ordering}(m::SortedSet{K,Ord}) = K
 @inline orderobject(m::SortedSet) = m.bt.ord
 
@@ -313,3 +330,6 @@ function Base.show{K,Ord <: Ordering}(io::IO, m::SortedSet{K,Ord})
     print(io, orderobject(m))
     print(io, ")")
 end
+
+similar{K,Ord<:Ordering}(m::SortedSet{K,Ord}) = 
+SortedSet{K,Ord}(orderobject(m))

--- a/test/test_sortedcontainers.jl
+++ b/test/test_sortedcontainers.jl
@@ -6,6 +6,7 @@ import Base.Reverse
 import DataStructures.eq
 import Base.lt
 import Base.ForwardOrdering
+import DataStructures.IntSemiToken
 
 ## Function fulldump dumps the entire tree; helpful for debugging.
 
@@ -443,6 +444,8 @@ function test2()
     @test wwx[1] == 2
     tpr = eltype(m1)
     @test tpr == @compat Tuple{Int,Float64}
+    tpr2 = eltype(typeof(m1))
+    @test tpr2 == @compat Tuple{Int,Float64}
     co = orderobject(m1)
     @test co == Forward
     @test haskey(m1, 71)
@@ -531,6 +534,8 @@ function test3{T}(z::T)
             count += 1
         end
     end
+    @test eltype(semitokens(exclusive(m1, startof(m1), pastendsemitoken(m1)))) ==
+       @compat Tuple{IntSemiToken, T, T}
     @test count == N^2
     N = 10000
     sk = zero1
@@ -563,17 +568,23 @@ function test3{T}(z::T)
     for k in keys(m1)
         sk2 += k
     end
+    @test eltype(keys(m1)) == T
+
     @test sk2 == sk
     sv2 = zero1
     for v in values(m1)
         sv2 += v
     end
+    @test eltype(values(m1)) == T
+
     @test sv == sv2
     count = 0
     for (st,k) in semitokens(keys(m1))
         @test deref_key((m1,st)) == k
         count += 1
     end
+    @test eltype(semitokens(keys(m1))) == @compat Tuple{IntSemiToken, T}
+                 
     @test count == N
     count = 0
     for (st,v) in semitokens(values(m1))
@@ -581,6 +592,7 @@ function test3{T}(z::T)
         count += 1
     end
     @test count == N
+    @test eltype(semitokens(values(m1))) == @compat Tuple{IntSemiToken, T}
 
     pos1 = searchsortedfirst(m1, div(N,2))
     sk2 = zero1
@@ -588,6 +600,9 @@ function test3{T}(z::T)
         sk2 += k
     end
     @test sk2 == skhalf
+    @test eltype(keys(exclusive(m1, startof(m1), pos1))) == T
+
+
     sv2 = zero1
     for v in values(exclusive(m1, startof(m1), pos1))
         sv2 += v
@@ -597,12 +612,15 @@ function test3{T}(z::T)
     for (k,v) in exclusive(m1, pastendsemitoken(m1), pastendsemitoken(m1))
         count += 1
     end
+    @test eltype(keys(exclusive(m1, startof(m1), pos1))) == T
     @test count == 0
     count = 0
     for (k,v) in inclusive(m1, startof(m1), beforestartsemitoken(m1))
         count += 1
     end
     @test count == 0
+    @test eltype(keys(inclusive(m1, startof(m1), beforestartsemitoken(m1)))) == 
+       T
 
     factors = SortedMultiDict(Int[], Int[])
     N = 1000
@@ -635,6 +653,9 @@ function test3{T}(z::T)
     end
 
     @test sum2 == 1 + 2 + 5 + 7 + 10 + 14 + 35 + 70
+    @test eltype(inclusive(factors, 
+                           searchsortedfirst(factors,70),
+                           searchsortedlast(factors,70))) == @compat Tuple{Int,Int}
     
     sum3 = 0
     for (k,v) in exclusive(factors,
@@ -643,12 +664,16 @@ function test3{T}(z::T)
         sum3 += v
     end
     @test sum3 == 1 + 2 + 3 + 4 + 5 + 6 + 10 + 12 + 15 + 20 + 30 + 60
+    @test eltype(exclusive(factors, 
+                           searchsortedfirst(factors,70),
+                           searchsortedlast(factors,70))) == @compat Tuple{Int,Int}
 
     sum4 = 0
     for k in keys(factors)
         sum4 += k
     end
     @test sum4 == sum1
+    @test eltype(keys(factors)) == Int
 
     sum5 = 0
     for v in values(factors)
@@ -656,6 +681,7 @@ function test3{T}(z::T)
     end
 
     @test sum5 == sum2a
+    @test eltype(values(factors)) == Int
 
     sum2 = 0
     for k in keys(inclusive(factors,
@@ -664,6 +690,10 @@ function test3{T}(z::T)
         sum2 += k
     end
     @test sum2 == 70 * 8
+    @test eltype(keys(inclusive(factors,
+                                searchsortedfirst(factors,70),
+                                searchsortedlast(factors,70)))) ==  Int
+
     
     sum3 = 0
     for k in keys(exclusive(factors,
@@ -672,6 +702,11 @@ function test3{T}(z::T)
         sum3 += k
     end
     @test sum3 == 60 * 12
+    @test eltype(keys(exclusive(factors,
+                                searchsortedfirst(factors,60), 
+                                searchsortedfirst(factors,61)))) == Int
+
+
 
     sum2 = 0
     for v in values(inclusive(factors,
@@ -680,6 +715,9 @@ function test3{T}(z::T)
         sum2 += v
     end
     @test sum2 == 1 + 2 + 5 + 7 + 10 + 14 + 35 + 70
+    @test eltype(values(inclusive(factors,
+                                  searchsortedfirst(factors,60), 
+                                  searchsortedfirst(factors,61)))) == Int
     
     sum3 = 0
     for v in values(exclusive(factors,
@@ -688,6 +726,9 @@ function test3{T}(z::T)
         sum3 += v
     end
     @test sum3 == 1 + 2 + 3 + 4 + 5 + 6 + 10 + 12 + 15 + 20 + 30 + 60
+    @test eltype(values(exclusive(factors,
+                                  searchsortedfirst(factors,60), 
+                                  searchsortedfirst(factors,61)))) == Int
 
     sum1b = 0
     sum2b = 0
@@ -697,6 +738,7 @@ function test3{T}(z::T)
         sum2b += v
     end
     @test sum1b == sum1a && sum2b == sum2a
+    @test eltype(semitokens(factors)) == @compat Tuple{IntSemiToken, Int, Int}
 
     sum2 = 0
     for (st,k,v) in semitokens(inclusive(factors,
@@ -706,6 +748,10 @@ function test3{T}(z::T)
         sum2 += v
     end
     @test sum2 == 1 + 2 + 5 + 7 + 10 + 14 + 35 + 70
+    @test eltype(semitokens(inclusive(factors,
+                                         searchsortedfirst(factors,70),
+                                         searchsortedlast(factors,70)))) ==
+        @compat Tuple{IntSemiToken, Int, Int}
     
     sum3 = 0
     for (st,k,v) in semitokens(exclusive(factors,
@@ -715,13 +761,18 @@ function test3{T}(z::T)
         sum3 += v
     end
     @test sum3 == 1 + 2 + 3 + 4 + 5 + 6 + 10 + 12 + 15 + 20 + 30 + 60
-
+    @test eltype(semitokens(exclusive(factors,
+                                      searchsortedfirst(factors,60), 
+                                      searchsortedfirst(factors,61)))) ==
+         @compat Tuple{IntSemiToken, Int, Int}
+    
     sum4 = 0
     for (st,k) in semitokens(keys(factors))
         @test deref_key((factors,st)) == k && mod(k,deref_value((factors,st))) == 0
         sum4 += k
     end
     @test sum4 == sum1
+    @test eltype(semitokens(keys(factors))) == @compat Tuple{IntSemiToken,Int}
 
     sum5 = 0
     for (st,v) in semitokens(values(factors))
@@ -729,6 +780,7 @@ function test3{T}(z::T)
         sum5 += v
     end
     @test sum5 == sum2a
+    @test eltype(semitokens(values(factors))) == @compat Tuple{IntSemiToken,Int}
 
     sum2 = 0
     for (st,k) in semitokens(keys(inclusive(factors,
@@ -738,6 +790,10 @@ function test3{T}(z::T)
         sum2 += k
     end
     @test sum2 == 70 * 8
+    @test eltype(semitokens(keys(inclusive(factors,
+                                           searchsortedfirst(factors,70),
+                                           searchsortedlast(factors,70))))) ==
+        @compat Tuple{IntSemiToken, Int}
     
     sum3 = 0
     for (st,k) in semitokens(keys(inclusive(factors,
@@ -747,6 +803,10 @@ function test3{T}(z::T)
         sum3 += k
     end
     @test sum3 == 60 * 12
+    @test eltype(semitokens(keys(inclusive(factors,
+                                            searchsortedfirst(factors,60), 
+                                            searchsortedlast(factors,60))))) ==
+        @compat Tuple{IntSemiToken, Int}
 
     sum2 = 0
     for (st,v) in semitokens(values(inclusive(factors,
@@ -756,6 +816,10 @@ function test3{T}(z::T)
         sum2 += v
     end
     @test sum2 == 1 + 2 + 5 + 7 + 10 + 14 + 35 + 70
+    @test eltype(semitokens(values(inclusive(factors,
+                                              searchsortedfirst(factors,70),
+                                              searchsortedlast(factors,70))))) ==
+      @compat Tuple{IntSemiToken, Int}
     
     sum3 = 0
     for (st,v) in semitokens(values(exclusive(factors,
@@ -765,6 +829,11 @@ function test3{T}(z::T)
         sum3 += v
     end
     @test sum3 == 1 + 2 + 3 + 4 + 5 + 6 + 10 + 12 + 15 + 20 + 30 + 60
+    @test eltype(semitokens(values(exclusive(factors,
+                                              searchsortedfirst(factors,60), 
+                                              searchsortedfirst(factors,61))))) ==
+       @compat Tuple{IntSemiToken, Int}
+    
     
 
     s = SortedSet([39, 24, 2, 14, 45, 107, 66])
@@ -780,6 +849,7 @@ function test3{T}(z::T)
         sum1 += k
     end
     @test sum1 == sum([39, 24, 2, 14, 45, 107, 66])
+    @test eltype(semitokens(s)) == @compat Tuple{IntSemiToken, Int}
 
     sum2 = 0
     for k in inclusive(s,
@@ -788,6 +858,13 @@ function test3{T}(z::T)
         sum2 += k
     end
     @test sum2 == 24 + 39 + 45 + 66
+    @test eltype(inclusive(s,
+                       searchsortedfirst(s, 24), 
+                       searchsortedfirst(s, 66))) == Int
+
+
+
+
     sum2 = 0
     for (st,k) in semitokens(inclusive(s,
                                        searchsortedfirst(s, 24),
@@ -796,6 +873,10 @@ function test3{T}(z::T)
         sum2 += k
     end
     @test sum2 == 24 + 39 + 45 + 66
+    @test eltype(semitokens(inclusive(s,
+                                       searchsortedfirst(s, 24),
+                                       searchsortedfirst(s, 66)))) ==
+      @compat Tuple{IntSemiToken, Int}
 
     sum3 = 0
     for k in exclusive(s,
@@ -804,6 +885,9 @@ function test3{T}(z::T)
         sum3 += k
     end
     @test sum3 == 24 + 39 + 45
+    @test eltype(exclusive(s,
+                       searchsortedfirst(s, 24), 
+                       searchsortedfirst(s, 66))) == Int
         
     sum3 = 0
 
@@ -814,6 +898,10 @@ function test3{T}(z::T)
         sum3 += k
     end
     @test sum3 == 24 + 39 + 45
+    @test eltype(semitokens(exclusive(s,
+                                       searchsortedfirst(s, 24), 
+                                       searchsortedfirst(s, 66)))) ==
+     @compat Tuple{IntSemiToken, Int}
 end
 
 
@@ -912,6 +1000,8 @@ function test5()
     for j = 1 : 6
         m3[keylist[j]] = vallist[j]
     end
+    @test "BERRY" in keys(m3)
+    @test !("BERRY" in collect(keys(m3)))
     checkcorrectness(m3.bt, false)
     expectedord3 = [2,3,4,5,6]
     count = 0
@@ -921,6 +1011,10 @@ function test5()
                 p[2] == vallist[expectedord3[count]]
     end
     @test count == 5
+    m3empty = similar(m3)
+    @test (eltype(m3empty) == @compat Tuple{ASCIIString, Int}) &&
+       orderobject(m3empty) == CaseInsensitive() &&
+       length(m3empty) == 0
     m4 = SortedDict((@compat Dict{ASCIIString,Int}()), Lt((x,y) -> isless(lowercase(x),lowercase(y))))
     for j = 1 : 6
         m4[keylist[j]] = vallist[j]
@@ -1077,9 +1171,12 @@ function test7()
     @test !((70,15) in factors)
     @test !((N+1,15) in factors)
     @test eltype(factors) == @compat Tuple{Int,Int}
+    @test eltype(typeof(factors)) == @compat Tuple{Int,Int}
     @test orderobject(factors) == Forward
     @test haskey(factors, 60)
     @test !haskey(factors, -1)
+    @test 60 in keys(factors)
+    @test !(-1 in keys(factors))
     checkcorrectness(factors.bt, true)
     i = startof(factors)
     i = advance((factors,i))
@@ -1181,6 +1278,10 @@ function test7()
                           "cherries", "cherries", "cherries", "cherries",
                           "oranges", "plums"],
                          [2.0, 6.0, 1.0, 9.0, 3.0, 4.0, 7.0, 8.0, 5.0, 10.0])
+    m3empty = similar(m3)
+    @test (eltype(m3empty) == @compat Tuple{ASCIIString, Float64}) &&
+        orderobject(m3empty) == Forward &&
+        length(m3empty) == 0
     m4 = merge(m1, m2)
     @test isequal(m3, m4)
     m5 = merge(m2, m1)
@@ -1212,6 +1313,9 @@ function test7()
         end
         @test count == 2
     end
+
+
+
 end
     
 
@@ -1300,6 +1404,7 @@ function test8()
     @test !(0.5 in m)
     @test !haskey(m,0.5)
     @test eltype(m) == Float64
+    @test eltype(typeof(m)) == Float64
     @test orderobject(m) == Forward
     pop!(m, smallest)
     checkcorrectness(m.bt, false)
@@ -1314,6 +1419,9 @@ function test8()
     m1 = SortedSet(["blue", "orange", "red"])
     m2 = SortedSet(["orange", "blue", "red"])
     m3 = SortedSet(["orange", "yellow", "red"])
+    m3empty = similar(m3)
+    @test eltype(m3empty) == ASCIIString &&
+       length(m3empty) == 0
     @test isequal(m1,m2)
     @test !isequal(m1,m3)
     @test !isequal(m1, SortedSet(["blue"]))
@@ -1359,6 +1467,63 @@ function test8()
     @test isequal(m8, SortedSet(["blue", "orange"]))
 end    
                
+
+# test the constructors of SortedDict and SortedMultiDict
+if VERSION >= v"0.4.0-dev"
+
+    function test9()
+
+        sd1 = SortedDict("w" => 64, "p" => 12)
+        @test length(sd1) == 2 && first(sd1) == ("p",12) &&
+            last(sd1) == ("w",64)
+        sd2 = SortedDict(Reverse, "w" => 64, "p" => 12)
+        @test length(sd2) == 2 && last(sd2) == ("p",12) &&
+            first(sd2) == ("w",64)
+        sd3 = SortedDict((("w",64), ("p",12)))
+        @test length(sd3) == 2 && first(sd3) == ("p",12) &&
+            last(sd3) == ("w",64)
+        sd4 = SortedDict((("w", 64), ("p",12)), Reverse)
+        @test length(sd4) == 2 && last(sd4) == ("p",12) &&
+            first(sd4) == ("w",64)
+        sm1 = SortedMultiDict("w" => 64, "p" => 12, "p" => 9)
+        @test length(sm1) == 3 && first(sm1) == ("p",12) &&
+            last(sm1) == ("w",64)
+        sm2 = SortedMultiDict(Reverse, "w" => 64, "p" => 12, "p" => 9)
+        @test length(sm2) == 3 && last(sm2) == ("p",9) &&
+            first(sm2) == ("w",64)
+        sm3 = SortedMultiDict((("w",64), ("p",12), ("p", 9)))
+        @test length(sm3) == 3 && first(sm3) == ("p",12) &&
+            last(sm3) == ("w",64)
+        sm4 = SortedMultiDict((("w", 64), ("p",12), ("p", 9)), Reverse)
+        @test length(sm4) == 3 && last(sm4) == ("p",9) &&
+            first(sm4) == ("w",64)
+    end
+else
+    function test9()
+        sd1 = SortedDict(["w", "p"], [64,12])
+        @test length(sd1) == 2 && first(sd1) == ("p",12) &&
+            last(sd1) == ("w",64)
+        sd2 = SortedDict(["w", "p"], [64,12], Reverse)
+        @test length(sd2) == 2 && last(sd2) == ("p",12) &&
+            first(sd2) == ("w",64)
+        sd3 = SortedDict([("w",64), ("p",12)])
+        @test length(sd3) == 2 && first(sd3) == ("p",12) &&
+            last(sd3) == ("w",64)
+        sd4 = SortedDict([("w", 64), ("p",12)], Reverse)
+        @test length(sd4) == 2 && last(sd4) == ("p",12) &&
+            first(sd4) == ("w",64)
+        sm3 = SortedMultiDict([("w",64), ("p",12), ("p", 9)])
+        @test length(sm3) == 3 && first(sm3) == ("p",12) &&
+            last(sm3) == ("w",64)
+        sm4 = SortedMultiDict([("w", 64), ("p",12), ("p", 9)], Reverse)
+        @test length(sm4) == 3 && last(sm4) == ("p",9) &&
+            first(sm4) == ("w",64)
+    end
+end
+
+
+
+
         
     
 test1()
@@ -1369,4 +1534,4 @@ test5()
 #test6(2, "soothingly", "compere")
 test7()
 test8()
-
+test9()


### PR DESCRIPTION
…n' function

Added more constructors for SortedDict and SortedMultiDict to mimic bulit-in Dict constructors; added code for fast lookup of in(k, keys(sc)) where sc is is a SortedDict or SortedMultiDict.

Did not address issue #112 because it appears that the changed to IntSet in 0.4 is going to be reverted soon.