### PR TITLE
added iter method to stack and queue

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -17,7 +17,7 @@ module DataStructures
                  find, searchsortedfirst, searchsortedlast, endof
 
     export Deque, Stack, Queue
-    export deque, enqueue!, dequeue!, update!
+    export deque, enqueue!, dequeue!, update!,iter
     export capacity, num_blocks, front, back, top, sizehint
 
     export Accumulator, counter

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -19,3 +19,11 @@ function enqueue!(s::Queue, x)
 end
 
 dequeue!(s::Queue) = shift!(s.store)
+
+function iter{T}(q::Queue{Deque{T}})
+    a = T[]
+    for i in q.store
+        push!(a,i)
+    end
+    return a
+end

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -17,4 +17,15 @@ function push!(s::Stack, x)
     s
 end
 
+#returns a collection that can be used in a for loop
+function iter{T}(s::Stack{Deque{T}})
+    a = T[]
+    for i in s.store
+        unshift!(a,i)
+    end
+    return a
+end
+
 pop!(s::Stack) = pop!(s.store)
+
+

--- a/test/test_stack_and_queue.jl
+++ b/test/test_stack_and_queue.jl
@@ -32,6 +32,21 @@ for i = 1 : n
     @test length(s) == n - i
 end
 
+#test that iter returns a LIFO collection 
+
+stk = Stack(Int, 10)
+#an array to check iteration sequence against
+arr = Int64[] 
+
+for i = 1:n
+    push!(stk,i)
+    push!(arr,i)
+end
+
+iterated = iter(stk)
+@test(reverse(arr) == iterated)
+
+
 # Queue
 
 s = Queue(Int, 5)
@@ -64,3 +79,17 @@ for i = 1 : n
     @test isempty(s) == (i == n)
     @test length(s) == n - i
 end
+
+#test that iter returns a FIFO collection 
+
+q = Queue(Int, 10)
+#an array to check iteration sequence against
+arr = Int64[] 
+
+for i = 1:n
+    enqueue!(q,i)
+    push!(arr,i)
+end
+
+iterated = iter(q)
+@test(arr == iterated)


### PR DESCRIPTION
 which returns an array with Stack elements in LIFO order/Queue elements in FIFO order.

This is essentially the fix for https://github.com/JuliaLang/DataStructures.jl/issues/116

This PR only adds the iter method with LIFO semantics for Stack and FIFO semantics for queue. 

The Stacks and Queues are still parametrized by the underlying container (Deque{T}) than the element type. I think these datastructures should ideally be parametrlized by the element type, and not implementation details which causes an abstraction leak. 

However I have *not* changed this in this PR's code, only added an iter method which returns an array with the elements in an order that makes sense for the datastructure - LIFO for Stack and FIFO for queue. I finally went with @lindahua 's concept than by implementing next() etc because this makes it easier to add alternate traversal schemes later.