### PR TITLE
Add precompile directive

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -1,3 +1,5 @@
+VERSION >= v"0.4.0-dev+6521" && __precompile__()
+
 module DataStructures
 
     using Compat


### PR DESCRIPTION
Passed `Pkg.test` on 0.4. Needed to resolve dependencies during precompilation.