### PR TITLE
Serialize & deserialize hashdicts in Julia 0.4

### DIFF
--- a/src/hashdict.jl
+++ b/src/hashdict.jl
@@ -91,7 +91,7 @@ similar{K,V,O}(d::HashDict{K,V,O}) = HashDict{K,V,O}()
 
 function serialize(s::SerState, t::HashDict)
     serialize_type(s, typeof(t))
-    write(s, int32(length(t)))
+    serialize(s, @compat Int32(length(t)))
     for (k,v) in t
         serialize(s, k)
         serialize(s, v)
@@ -99,7 +99,7 @@ function serialize(s::SerState, t::HashDict)
 end
 
 function deserialize{K,V,O}(s::SerState, T::Type{HashDict{K,V,O}})
-    n = read(s, Int32)
+    n = deserialize(s)
     t = T(); sizehint(t, n)
     for i = 1:n
         k = deserialize(s)

--- a/test/test_ordereddict.jl
+++ b/test/test_ordereddict.jl
@@ -314,3 +314,18 @@ let
     @test d['f'] == 6
     @test length(d) == 6
 end
+
+# Test serialization
+let
+    s = IOBuffer()
+    od = OrderedDict{Char,Int64}()
+    for c in 'a':'e'
+        od[c] = c-'a'+1
+    end
+    serialize(s, od)
+    seek(s, 0)
+    dd = deserialize(s)
+    @test typeof(dd) === DataStructures.OrderedDict{Char,Int64}
+    @test dd == od
+    close(s)
+end


### PR DESCRIPTION
The signature of `write` changed a bit in Julia 0.4, and using `SerState` (ie. `Base.Serializer.SerializationState`) directly doesn't work. `s.io` works in 0.4 but wouldn't be backwards compatible with Julia 0.3.

Using the `serialize` method provided in the Julia distribution will allow the base library to make the appropriate call.