### PR TITLE
Remove support for Julia 0.3 from src/test/readme of sorted containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - linux
     - osx
 julia: 
-    - 0.3
     - 0.4
     - nightly
 notifications:

--- a/README.rst
+++ b/README.rst
@@ -483,13 +483,9 @@ Constructors for Sorted Containers
 
 ``SortedDict(d)``
   Argument ``d`` is an ordinary Julia dict (or any associative type)
-  used to initialize the container, e.g., for Julia 0.4/0.5::
+  used to initialize the container::
 
      c = SortedDict(Dict("New York" => 1788, "Illinois" => 1818))
-
-  or for 0.3::
-
-     c = SortedDict(["New York" => 1788, "Illinois" => 1818])
 
 
   In this example the key-type is deduced to be ASCIIString, while the
@@ -505,40 +501,29 @@ Constructors for Sorted Containers
   Arguments are key-value pairs for insertion into the 
   dictionary.  
   The keys must be of the same type as one another; the
-  values must also be of one type.  (Julia 0.4/0.5 only.)
+  values must also be of one type. 
 
 ``SortedDict(o, k1=>v1, k2=>v2, ...)``
   The first argument ``o`` is an ordering object.  The remaining
   arguments are key-value pairs for insertion into the 
   dictionary.  
   The keys must be of the same type as one another; the
-  values must also be of one type. (Julia 0.4/0.5 only.)
+  values must also be of one type. 
 
 ``SortedDict(iter)``
   Takes an arbitrary iterable object of key=>value pairs.
-  The default Forward ordering is used.  In Julia 0.3,
-  the ``iter`` argument must be an ``AbstractArray`` of
-  key-value two-entry tuples.
+  The default Forward ordering is used.  
 
 ``SortedDict(iter,o)``
   Takes an arbitrary iterable object of key=>value pairs.
-  The ordering object ``o`` is explicitly given.  In Julia 0.3,
-  the ``iter`` argument must be an ``AbstractArray`` of
-  key-value two-entry tuples.
+  The ordering object ``o`` is explicitly given.  
 
 ``SortedDict{K,V,Ord}(o)``
   Construct an empty SortedDict in which type parameters
   are explicitly listed; ordering object is explicitly specified.
   (See below for discussion of ordering.)  An empty SortedDict
   may also be constructed using ``SortedDict(Dict{K,V}(),o)`` 
-  in Julia 0.4/0.5, where the ``o`` argument is optional, or 
-  ``SortedDict((K=>V)[],o)`` in Julia 0.3.
-
-``SortedDict(ks,vs,o)``
-  Here, ``ks`` is an array of keys, ``vs`` is an array of values
-  of the same length, and ``o`` is the optional ordering argument.
-  This syntax is available in Julia 0.3 only.  In Julia 0.4/0.5,
-  use ``SortedDict(zip(ks,vs),o).``
+  where the ``o`` argument is optional.
 
 ``SortedMultiDict(ks,vs,o)``
   Construct a SortedMultiDict using keys given by ``ks``, values
@@ -552,7 +537,7 @@ Constructors for Sorted Containers
   Arguments are key-value pairs for insertion into the 
   multidict.  
   The keys must be of the same type as one another; the
-  values must also be of one type.  Julia 0.4/0.5 only.
+  values must also be of one type. 
 
 
 ``SortedMultiDict(o, k1=>v1, k2=>v2, ...)``
@@ -560,21 +545,16 @@ Constructors for Sorted Containers
   arguments are key-value pairs for insertion into the 
   multidict.
   The keys must be of the same type as one another; the
-  values must also be of one type. Julia 0.4/0.5 only.
+  values must also be of one type.
 
 
 ``SortedMultiDict(iter)``
   Takes an arbitrary iterable object of key=>value pairs.
-  The default Forward ordering is used.  In Julia 0.3, 
-  the ``iter`` argument must be an ``AbstractArray``
-  of (key,value) tuples.
+  The default Forward ordering is used. 
 
 ``SortedMultiDict(iter,o)``
   Takes an arbitrary iterable object of key=>value pairs.
   The ordering object ``o`` is explicitly given.
-  In Julia 0.3, 
-  the ``iter`` argument must be an ``AbstractArray``
-  of (key,value) tuples.
 
 
 ``SortedMultiDict{K,V,Ord}(o)``
@@ -633,10 +613,9 @@ Navigating the Containers
   is a token (i.e., ``sc`` is a container and ``st`` is a semitoken).
   Note the double-parentheses in the calling syntax: the argument of ``deref``
   is  a token, which is defined to be a 2-tuple.
-  This returns the (key, value) 2-entry tuple in Julia 0.3 and a key=>value
-  pair in Julia 0.4/0.5
+  This returns a key=>value pair.
   pointed to by the token for SortedDict and SortedMultiDict.  
-  Note that in any one of Julia 0.3/0.4/0.5, the syntax
+  Note that the syntax
   ``k,v=deref((sc,st))`` is valid because Julia automatically iterates
   over the two entries of the Pair in order to assign ``k`` and ``v``.
   For SortedSet this returns a key.  Time: O(1)
@@ -671,8 +650,7 @@ Navigating the Containers
 
 ``first(sc)``
   Argument ``sc`` is a SortedDict, SortedMultiDict or SortedSet  This function
-  returns the first item (a ``k=>v`` pair for SortedDict and SortedMultiDict in 
-  Julia 0.4/0.5 or a ``(k,v)`` tuple in Julia 0.3;
+  returns the first item (a ``k=>v`` pair for SortedDict and SortedMultiDict or
   a key for SortedSet)
   according
   to the sorted order in the container.  Thus, ``first(sc)`` is
@@ -682,9 +660,8 @@ Navigating the Containers
 
 ``last(sc)``
   Argument ``sc`` is a SortedDict, SortedMultiDict or SortedSet.  This function
-  returns the last item (a ``k=>v`` pair for SortedDict and SortedMultiDict in
-  Julia 0.4/0.5 or a ``(k,v)`` tuple in Julia 0.3; 
-  a key for SortedSet)
+  returns the last item (a ``k=>v`` pair for SortedDict and SortedMultiDict
+  or   a key for SortedSet)
   according
   to the sorted order in the container.  Thus, ``last(sc)`` is
   equivalent to ``deref((sc,endof(sc)))``.
@@ -811,8 +788,7 @@ Inserting & Deleting in Sorted Containers
   this overwrites
   the old value. 
   The return
-  value is ``sc``.  In Julia 0.3, the syntax for this call
-  is ``push!(sc, k, v)``.
+  value is ``sc``. 
   Time: O(*c* log *n*)
 
 
@@ -926,8 +902,7 @@ the sort order of the key.  If one uses::
   end
 
 where ``sc`` is a SortedDict or SortedMultiDict, then ``p`` is
-a ``k=>v`` pair in Julia 0.4/0.5 or a ``(k,v)`` tuple in Julia 0.3.
-
+a ``k=>v`` pair.
 
 For SortedSet one uses::
 
@@ -966,9 +941,7 @@ In this setting, either or both can be the past-end token, and ``(sc,st2)`` can
 be the before-start token. For the sake
 of consistency, ``exclusive`` also supports the calling format
 ``exclusive(sc,(st1,st2))``.  In the previous few snippets, if the loop
-object is ``p`` instead of ``(k,v)``, then ``p`` is a ``k=>v`` pair in Julia
-0.4/0.5 and a ``(k,v)`` tuple in Julia 0.3.
-
+object is ``p`` instead of ``(k,v)``, then ``p`` is a ``k=>v`` pair.
 
 
 Both the ``inclusive`` and ``exclusive`` functions return objects that can be 
@@ -1028,11 +1001,10 @@ If one wishes to retrieve only semitokens, the following may be used::
        < body >
    end
 
-   
 
 In this case, ``sc`` is a SortedDict, SortedMultiDict, or SortedSet.
 To be compatible with standard containers, the package also offers
-``eachindex`` iteration (Julia 0.4/0.5 only)::
+``eachindex`` iteration::
 
 
    for ind in eachindex(sc)
@@ -1073,8 +1045,8 @@ Other Functions
 ``in(p,sc)``
   Returns true if ``p`` is in ``sc``.  In the
   case that ``sc`` is a SortedDict or SortedMultiDict,
-  ``p`` is a (key,value) tuple in Julia 0.3 or a key=>value
-  pair in Julia 0.4/0.5.  In the case that ``sc``
+  ``p`` is a key=>value
+  pair.  In the case that ``sc``
   is a SortedSet, ``p`` should be a key.
   Time: O(*c* log *n*) for SortedDict and SortedSet.
   In the case of SortedMultiDict, the time is
@@ -1099,8 +1071,7 @@ Other Functions
   semitokens, ``k`` is a key, and ``v`` is a value, will
   loop over all entries in the dictionary between
   the two tokens and a compare for equality using ``isequal`` between the
-  indexed item and ``k=>v``.  (In Julia 0.3, the syntax would be
-  ``(k,v) in exclusive(sd, st1, st2)``.)
+  indexed item and ``k=>v``.
 
   The five exceptions are::
 
@@ -1112,7 +1083,6 @@ Other Functions
 
   Here, ``sd`` is a SortedDict,
   ``smd`` is a SortedMultiDict, and ``ss`` is a SortedSet.
-  In the first two items, one uses ``(k,v)`` for Julia 0.3 rather than ``k=>v``.
 
   These five invocations of ``in``
   use the index structure
@@ -1134,8 +1104,7 @@ Other Functions
 
 
 ``eltype(sc)``
-  Returns the (key,value) type (a 2-entry pair, i.e., ``Pair{K,V}`` in
-  Julia 0.4/0.5; a 2-tuple type ``(K,V)`` in Julia 0.3)
+  Returns the (key,value) type (a 2-entry pair, i.e., ``Pair{K,V}``)
   for SortedDict and SortedMultiDict.
   Returns the key type for SortedSet.  This function may
   also be applied to the type itself.
@@ -1145,7 +1114,7 @@ Other Functions
   Returns the key type 
   for SortedDict, SortedMultiDict and SortedSet.
   This function may
-  also be applied to the type itself.  Julia 0.4/0.5 only.
+  also be applied to the type itself. 
   Time: O(1)
 
 
@@ -1153,10 +1122,8 @@ Other Functions
   Returns the value type 
   for SortedDict and SortedMultiDict.
   This function may
-  also be applied to the type itself. Julia 0.4/0.5 only.
+  also be applied to the type itself.
   Time: O(1)
-
-
 
 
 

--- a/src/containerloops.jl
+++ b/src/containerloops.jl
@@ -259,21 +259,12 @@ end
 
 
 
-if VERSION >= v"0.4.0-dev"
 
 @inline function next(u::SDMIterableTypesBase, state::SAIterationState)
     dt, t, ni = nexthelper(u, state)
     (dt.k => dt.d), ni
 end
 
-else 
-
-@inline function next(u::SDMIterableTypesBase, state::SAIterationState)
-    dt, t, ni = nexthelper(u, state)
-    (dt.k, dt.d), ni
-end
-
-end
 
 @inline function next(u::SSIterableTypesBase, state::SAIterationState)
     dt, t, ni = nexthelper(u, state)
@@ -326,14 +317,6 @@ eachindex{K,D,Ord <: Ordering}(sd::SDMIncludeLast{SortedDict{K,D,Ord}}) = keys(s
 eachindex{K,D,Ord <: Ordering}(smd::SDMIncludeLast{SortedMultiDict{K,D,Ord}}) = 
      onlysemitokens(smd)
 eachindex(ss::SSIncludeLast) = onlysemitokens(ss)
-
-
-
-
-
-
-
-
 
 
 empty!(m::SAContainer) =  empty!(m.bt)

--- a/src/sortedDict.jl
+++ b/src/sortedDict.jl
@@ -26,70 +26,46 @@ function SortedDict{K, D, Ord <: Ordering}(d::Associative{K,D}, o::Ord=Forward)
 end
 
 
-if VERSION >= v"0.4.0-dev"
 
-    ## More constructors based on those in dict.jl:
-    ## Take pairs and infer argument
-    ## types.  Note:  this works only for the Forward ordering.
+## More constructors based on those in dict.jl:
+## Take pairs and infer argument
+## types.  Note:  this works only for the Forward ordering.
 
-    function SortedDict{K,D}(ps::Pair{K,D}...)
-        h = SortedDict{K,D,ForwardOrdering}()
-        for p in ps
-            h[p.first] = p.second
-        end
-        h 
+function SortedDict{K,D}(ps::Pair{K,D}...)
+    h = SortedDict{K,D,ForwardOrdering}()
+    for p in ps
+        h[p.first] = p.second
     end
-
-
-    ## Take pairs and infer argument
-    ## types.  Ordering parameter must be explicit first argument.
-
-
-    function SortedDict{K,D, Ord <: Ordering}(o::Ord, ps::Pair{K,D}...)
-        h = SortedDict{K,D,Ord}(o)
-        for p in ps
-            h[p.first] = p.second
-        end
-        h 
-    end
-
-    ## This one takes an iterable; ordering type is optional.
-
-    SortedDict{Ord <: Ordering}(kv, o::Ord=Forward) = 
-    sorteddict_with_eltype(kv, eltype(kv), o)
-
-    function sorteddict_with_eltype{K,D,Ord}(kv, ::Type{Pair{K,D}}, o::Ord)
-        h = SortedDict{K,D,Ord}(o)
-        for (k,v) in kv
-            h[k] = v
-        end
-        h
-    end
-
-else   #if VERSION < v"0.4.0-dev"
-    function SortedDict{K,D,Ord <: Ordering}(ks::AbstractArray{K},
-                                             vs::AbstractArray{D},
-                                             o::Ord = Forward) 
-        h = SortedDict{K,D,Ord}(o)
-        l = length(ks)
-        if length(vs) != l
-            error("ks and vs arrays in two-array SortedDict constructor must have the same length")
-        end
-        for i = 1 : l
-            h[ks[i]] = vs[i]
-        end
-        h
-    end
-
-    function SortedDict{K,D,Ord <: Ordering}(kv::AbstractArray{(K,D),1},
-                                             o::Ord = Forward)
-        h = SortedDict{K,D,Ord}(o)
-        for pr in kv
-            h[pr[1]] = pr[2]
-        end
-        h
-    end
+    h 
 end
+
+
+## Take pairs and infer argument
+## types.  Ordering parameter must be explicit first argument.
+
+
+function SortedDict{K,D, Ord <: Ordering}(o::Ord, ps::Pair{K,D}...)
+    h = SortedDict{K,D,Ord}(o)
+    for p in ps
+        h[p.first] = p.second
+    end
+    h 
+end
+
+## This one takes an iterable; ordering type is optional.
+
+SortedDict{Ord <: Ordering}(kv, o::Ord=Forward) = 
+sorteddict_with_eltype(kv, eltype(kv), o)
+
+function sorteddict_with_eltype{K,D,Ord}(kv, ::Type{Pair{K,D}}, o::Ord)
+    h = SortedDict{K,D,Ord}(o)
+    for (k,v) in kv
+        h[k] = v
+    end
+    h
+end
+
+
 
 
 
@@ -120,20 +96,10 @@ end
 
 ## push! is an alternative to insert!; it returns the container.
 
-if VERSION >= v"0.4.0-dev"
 
 @inline function push!{K, D, Ord <: Ordering}(m::SortedDict{K,D,Ord}, pr::Pair{K,D})
     insert!(m.bt, convert(K,pr[1]), convert(D,pr[2]), false)
     m
-end
-
-else
-
-@inline function push!{K, D, Ord <: Ordering}(m::SortedDict{K,D,Ord}, k_, d_)
-    insert!(m.bt, convert(K,k_), convert(D,d_), false)
-    m
-end
-
 end
 
 
@@ -163,7 +129,6 @@ end
 end
 
 
-if VERSION >= v"0.4.0-dev"
 
 @inline eltype{K,D,Ord <: Ordering}(m::SortedDict{K,D,Ord}) =  Pair{K,D}
 @inline eltype{K,D,Ord <: Ordering}(::Type{SortedDict{K,D,Ord}}) =  Pair{K,D}
@@ -175,18 +140,6 @@ end
 @inline in(::Tuple{Any,Any}, ::SortedDict) =
     throw(ArgumentError("'(k,v) in sorteddict' not supported in Julia 0.4 or 0.5.  See documentation"))
 
-
-else
-
-@inline function in{K,D,Ord <: Ordering}(pr::(Any,Any), m::SortedDict{K,D,Ord})
-    i, exactfound = findkey(m.bt,convert(K,pr[1]))
-    return exactfound && isequal(m.bt.data[i].d,convert(D,pr[2]))
-end
-
-@inline eltype{K,D,Ord <: Ordering}(m::SortedDict{K,D,Ord}) =  (K,D)
-@inline eltype{K,D,Ord <: Ordering}(::Type{SortedDict{K,D,Ord}}) =  (K,D)
-
-end
 
 @inline keytype{K,D,Ord <: Ordering}(m::SortedDict{K,D,Ord}) = K
 @inline keytype{K,D,Ord <: Ordering}(::Type{SortedDict{K,D,Ord}}) = K

--- a/src/sortedMultiDict.jl
+++ b/src/sortedMultiDict.jl
@@ -35,62 +35,44 @@ function SortedMultiDict{K,D, Ord <: Ordering}(kk::AbstractArray{K,1},
 end
 
 
-if VERSION >= v"0.4.0-dev"
 
-    ## Take pairs and infer argument
-    ## types.  Note:  this works only for the Forward ordering.
+## Take pairs and infer argument
+## types.  Note:  this works only for the Forward ordering.
 
-    function SortedMultiDict{K,D}(ps::Pair{K,D}...)
-        h = SortedMultiDict{K,D,ForwardOrdering}()
-        for p in ps
-            insert!(h, p.first, p.second)
-        end
-        h 
+function SortedMultiDict{K,D}(ps::Pair{K,D}...)
+    h = SortedMultiDict{K,D,ForwardOrdering}()
+    for p in ps
+        insert!(h, p.first, p.second)
     end
-
-
-    ## Take pairs and infer argument
-    ## types.  Ordering parameter must be explicit first argument.
-
-
-    function SortedMultiDict{K,D, Ord <: Ordering}(o::Ord, ps::Pair{K,D}...)
-        h = SortedMultiDict{K,D,Ord}(o)
-        for p in ps
-            insert!(h, p.first, p.second)
-        end
-        h 
-    end
-
-
-    ## This one takes an iterable; ordering type is optional.
-
-    SortedMultiDict{Ord <: Ordering}(kv, o::Ord=Forward) = 
-    sortedmultidict_with_eltype(kv, eltype(kv), o)
-
-    function sortedmultidict_with_eltype{K,D,Ord}(kv, ::Type{Pair{K,D}}, o::Ord)
-        h = SortedMultiDict{K,D,Ord}(o)
-        for (k,v) in kv
-            insert!(h, k, v)
-        end
-        h
-    end
-
-
-else # if VERSION < v"0.4.0-dev"
-
-    function SortedMultiDict{K,D,Ord <: Ordering}(kv::AbstractArray{(K,D),1},
-                                                  o::Ord = Forward)
-        h = SortedMultiDict{K,D,Ord}(o)
-        for pr in kv
-            insert!(h, pr[1], pr[2])
-        end
-        h
-    end
+    h 
 end
 
 
+## Take pairs and infer argument
+## types.  Ordering parameter must be explicit first argument.
 
 
+function SortedMultiDict{K,D, Ord <: Ordering}(o::Ord, ps::Pair{K,D}...)
+    h = SortedMultiDict{K,D,Ord}(o)
+    for p in ps
+        insert!(h, p.first, p.second)
+    end
+    h 
+end
+
+
+## This one takes an iterable; ordering type is optional.
+
+SortedMultiDict{Ord <: Ordering}(kv, o::Ord=Forward) = 
+sortedmultidict_with_eltype(kv, eltype(kv), o)
+
+function sortedmultidict_with_eltype{K,D,Ord}(kv, ::Type{Pair{K,D}}, o::Ord)
+    h = SortedMultiDict{K,D,Ord}(o)
+    for (k,v) in kv
+        insert!(h, k, v)
+    end
+    h
+end
 
 
 ## This function inserts an item into the tree.
@@ -104,23 +86,11 @@ end
 
 ## push! is an alternative to insert!; it returns the container.
 
-if VERSION >= v"0.4.0-dev"
 
 @inline function push!{K, D, Ord <: Ordering}(m::SortedMultiDict{K,D,Ord}, pr::Pair{K,D})
     insert!(m.bt, convert(K,pr[1]), convert(D,pr[2]), true)
     m
 end
-
-else
-
-@inline function push!{K, D, Ord <: Ordering}(m::SortedMultiDict{K,D,Ord}, k_, d_)
-    insert!(m.bt, convert(K,k_), convert(D,d_), true)
-    m
-end
-
-end
-
-
 
 
 
@@ -179,8 +149,6 @@ end
 
  
 
-if VERSION >= v"0.4.0-dev"
-
 @inline eltype{K,D,Ord <: Ordering}(m::SortedMultiDict{K,D,Ord}) =  Pair{K,D}
 @inline eltype{K,D,Ord <: Ordering}(::Type{SortedMultiDict{K,D,Ord}}) =  Pair{K,D}
 @inline in(pr::Pair, m::SortedMultiDict) =
@@ -189,16 +157,6 @@ if VERSION >= v"0.4.0-dev"
     throw(ArgumentError("'(k,v) in sortedmultidict' not supported in Julia 0.4 or 0.5.  See documentation"))
 
 
-
-else
-
-
-@inline eltype{K,D,Ord <: Ordering}(m::SortedMultiDict{K,D,Ord}) =  (K,D)
-@inline eltype{K,D,Ord <: Ordering}(::Type{SortedMultiDict{K,D,Ord}}) =  (K,D)
-@inline in{K,D,Ord <: Ordering}(pr::(Any,Any), m::SortedMultiDict{K,D,Ord}) =
-    in_(pr[1], pr[2], m)
-
-end
 
 @inline keytype{K,D,Ord <: Ordering}(m::SortedMultiDict{K,D,Ord}) = K
 @inline keytype{K,D,Ord <: Ordering}(::Type{SortedMultiDict{K,D,Ord}}) = K

--- a/test/test_sortedcontainers.jl
+++ b/test/test_sortedcontainers.jl
@@ -76,21 +76,10 @@ function fulldump(t::DataStructures.BalancedTree23)
 end
 
 
-if VERSION >= v"0.4.0-dev"
 
 tuple_or_pair(K::DataType, V::DataType) = Pair{K,V}
 tuple_or_pair(k,v) = k=>v
 push_test!(m, k, v) = push!(m, k=>v)
-
-else
-
-tuple_or_pair(K::DataType, V::DataType) = (K,V)
-tuple_or_pair(k,v) = (k,v)
-push_test!(m, k, v) = push!(m, k, v)
-
-
-end
-
 
 
 
@@ -472,16 +461,14 @@ function test2()
     @test tpr == tuple_or_pair(Int,Float64)
     tpr2 = eltype(typeof(m1))
     @test tpr2 == tuple_or_pair(Int,Float64)
-    if VERSION >= v"0.4.0-dev"
-        kt = keytype(m1)
-        @test kt == Int
-        kt2 = keytype(typeof(m1))
-        @test kt2 == Int
-        vt = valtype(m1)
-        @test vt == Float64
-        vt2 = valtype(typeof(m1))
-        @test vt2 == Float64
-    end
+    kt = keytype(m1)
+    @test kt == Int
+    kt2 = keytype(typeof(m1))
+    @test kt2 == Int
+    vt = valtype(m1)
+    @test vt == Float64
+    vt2 = valtype(typeof(m1))
+    @test vt2 == Float64
     
 
     co = orderobject(m1)
@@ -612,16 +599,14 @@ function test3{T}(z::T)
     
     sk2a = zero1
 
-    if VERSION >= v"0.4.0-dev"
 
-        for k in eachindex(m1)
-            sk2a += k
-        end
-        @test eltype(eachindex(m1)) == T
-        @test sk2a == sk
-
+    for k in eachindex(m1)
+        sk2a += k
     end
+    @test eltype(eachindex(m1)) == T
+    @test sk2a == sk
 
+    
 
     sk2b = zero1
     for st in onlysemitokens(m1)
@@ -661,14 +646,13 @@ function test3{T}(z::T)
     @test eltype(keys(exclusive(m1, startof(m1), pos1))) == T
 
 
-    if VERSION >= v"0.4.0-dev"
-        sk2a = zero1
-        for k in eachindex(exclusive(m1, startof(m1), pos1))
-            sk2a += k
-        end
-        @test sk2a == skhalf
-        @test eltype(eachindex(exclusive(m1, startof(m1), pos1))) == T
+
+    sk2a = zero1
+    for k in eachindex(exclusive(m1, startof(m1), pos1))
+        sk2a += k
     end
+    @test sk2a == skhalf
+    @test eltype(eachindex(exclusive(m1, startof(m1), pos1))) == T
 
 
 
@@ -694,16 +678,14 @@ function test3{T}(z::T)
        T
 
 
-    if VERSION >= v"0.4.0-dev"
-        count = 0
-        sk5 = zero1
-        for k in eachindex(inclusive(m1, startof(m1), startof(m1)))
-            sk5 += k
-            count += 1
-        end
-        @test count == 1 && sk5 == deref_key((m1,startof(m1)))
-        @test eltype(eachindex(inclusive(m1, startof(m1), startof(m1)))) == T
+    count = 0
+    sk5 = zero1
+    for k in eachindex(inclusive(m1, startof(m1), startof(m1)))
+        sk5 += k
+        count += 1
     end
+    @test count == 1 && sk5 == deref_key((m1,startof(m1)))
+    @test eltype(eachindex(inclusive(m1, startof(m1), startof(m1)))) == T
 
     factors = SortedMultiDict(Int[], Int[])
     N = 1000
@@ -732,16 +714,14 @@ function test3{T}(z::T)
 
 
 
-    if VERSION >= v"0.4.0-dev"
-        sum1a = 0
-        sum2a = 0
-        for st in eachindex(factors)
-            (k,v) = deref((factors,st))
-            sum1a += k
-            sum2a += v
-        end
-        @test sum1a == sum1 && sum2a == sum2
+    sum1a = 0
+    sum2a = 0
+    for st in eachindex(factors)
+        (k,v) = deref((factors,st))
+        sum1a += k
+        sum2a += v
     end
+    @test sum1a == sum1 && sum2a == sum2
 
     sum1a = 0
     sum2a = 0
@@ -765,24 +745,22 @@ function test3{T}(z::T)
                            searchsortedfirst(factors,70),
                            searchsortedlast(factors,70))) == tuple_or_pair(Int,Int)
 
-    if VERSION >= v"0.4.0-dev"
 
-        sum2 = 0
-        for st in eachindex(inclusive(factors, 
-                                      searchsortedfirst(factors,70),
-                                      searchsortedlast(factors,70)))
-            v = deref_value((factors,st))
-            sum2 += v
-        end
-
-        @test sum2 == 1 + 2 + 5 + 7 + 10 + 14 + 35 + 70
-        @test eltype(eachindex(inclusive(factors, 
-                                         searchsortedfirst(factors,70),
-                                         searchsortedlast(factors,70)))) == IntSemiToken
+    sum2 = 0
+    for st in eachindex(inclusive(factors, 
+                                  searchsortedfirst(factors,70),
+                                  searchsortedlast(factors,70)))
+        v = deref_value((factors,st))
+        sum2 += v
     end
-
-
     
+    @test sum2 == 1 + 2 + 5 + 7 + 10 + 14 + 35 + 70
+    @test eltype(eachindex(inclusive(factors, 
+                                     searchsortedfirst(factors,70),
+                                     searchsortedlast(factors,70)))) == IntSemiToken
+
+
+
     sum3 = 0
     for (k,v) in exclusive(factors,
                            searchsortedfirst(factors,60), 
@@ -795,19 +773,17 @@ function test3{T}(z::T)
                            searchsortedlast(factors,70))) == tuple_or_pair(Int,Int)
 
 
-    if VERSION >= v"0.4.0-dev"
-        sum3 = 0
-        for st in eachindex(exclusive(factors,
-                                      searchsortedfirst(factors,60), 
-                                      searchsortedfirst(factors,61)))
-            v = deref_value((factors,st))
-            sum3 += v
-        end
-        @test sum3 == 1 + 2 + 3 + 4 + 5 + 6 + 10 + 12 + 15 + 20 + 30 + 60
-        @test eltype(eachindex(exclusive(factors, 
-                                         searchsortedfirst(factors,70),
-                                         searchsortedlast(factors,70)))) == IntSemiToken
+    sum3 = 0
+    for st in eachindex(exclusive(factors,
+                                  searchsortedfirst(factors,60), 
+                                  searchsortedfirst(factors,61)))
+        v = deref_value((factors,st))
+        sum3 += v
     end
+    @test sum3 == 1 + 2 + 3 + 4 + 5 + 6 + 10 + 12 + 15 + 20 + 30 + 60
+    @test eltype(eachindex(exclusive(factors, 
+                                     searchsortedfirst(factors,70),
+                                     searchsortedlast(factors,70)))) == IntSemiToken
 
 
     sum4 = 0
@@ -1003,16 +979,14 @@ function test3{T}(z::T)
     @test sum1 == sum([39, 24, 2, 14, 45, 107, 66])
     @test eltype(onlysemitokens(s)) == IntSemiToken
 
-    if VERSION >= v"0.4.0-dev"
 
-        sum1 = 0
-        for st in eachindex(s)
-            k = deref((s,st))
-            sum1 += k
-        end
-        @test sum1 == sum([39, 24, 2, 14, 45, 107, 66])
-        @test eltype(eachindex(s)) == IntSemiToken
+    sum1 = 0
+    for st in eachindex(s)
+        k = deref((s,st))
+        sum1 += k
     end
+    @test sum1 == sum([39, 24, 2, 14, 45, 107, 66])
+    @test eltype(eachindex(s)) == IntSemiToken
 
 
     sum2 = 0
@@ -1027,18 +1001,16 @@ function test3{T}(z::T)
                        searchsortedfirst(s, 66))) == Int
 
 
-    if VERSION >= v"0.4.0-dev"
-        sum2 = 0
-        for st in eachindex(inclusive(s,
-                                      searchsortedfirst(s, 24), 
-                                      searchsortedfirst(s, 66)))
-            sum2 += deref((s,st))
-        end
-        @test sum2 == 24 + 39 + 45 + 66
-        @test eltype(eachindex(inclusive(s,
-                                         searchsortedfirst(s, 24), 
-                                         searchsortedfirst(s, 66)))) == IntSemiToken
+    sum2 = 0
+    for st in eachindex(inclusive(s,
+                                  searchsortedfirst(s, 24), 
+                                  searchsortedfirst(s, 66)))
+        sum2 += deref((s,st))
     end
+    @test sum2 == 24 + 39 + 45 + 66
+    @test eltype(eachindex(inclusive(s,
+                                     searchsortedfirst(s, 24), 
+                                     searchsortedfirst(s, 66)))) == IntSemiToken
 
 
 
@@ -1096,19 +1068,17 @@ function test3{T}(z::T)
                                        searchsortedfirst(s, 66)))) ==
      @compat Tuple{IntSemiToken, Int}
 
-    if VERSION >= v"0.4.0-dev"
 
-        sum3 = 0
-        for st in eachindex(exclusive(s,
-                                      searchsortedfirst(s, 24), 
-                                      searchsortedfirst(s, 66)))
-            sum3 += deref((s,st))
-        end
-        @test sum3 == 24 + 39 + 45
-        @test eltype(eachindex(exclusive(s,
-                                         searchsortedfirst(s, 24), 
-                                         searchsortedfirst(s, 66)))) == IntSemiToken
+    sum3 = 0
+    for st in eachindex(exclusive(s,
+                                  searchsortedfirst(s, 24), 
+                                  searchsortedfirst(s, 66)))
+        sum3 += deref((s,st))
     end
+    @test sum3 == 24 + 39 + 45
+    @test eltype(eachindex(exclusive(s,
+                                     searchsortedfirst(s, 24), 
+                                     searchsortedfirst(s, 66)))) == IntSemiToken
     nothing
 end
 
@@ -1152,10 +1122,8 @@ function test4()
     @test_throws BoundsError last(s)
     @test_throws ArgumentError isequal(SortedSet(["a"]), SortedSet([1]))
     @test_throws ArgumentError isequal(SortedSet(["a"]), SortedSet(["b"],Reverse))
-    if VERSION >= v"0.4.0-dev"
-        @test_throws ArgumentError (("a",6) in m)
-        @test_throws ArgumentError ((2,5) in m1)
-    end
+    @test_throws ArgumentError (("a",6) in m)
+    @test_throws ArgumentError ((2,5) in m1)
     nothing
 end
 
@@ -1382,12 +1350,10 @@ function test7()
     @test eltype(factors) == tuple_or_pair(Int,Int)
     @test eltype(typeof(factors)) == tuple_or_pair(Int,Int)
 
-    if VERSION >= v"0.4.0-dev"
-        @test keytype(factors) == Int
-        @test keytype(typeof(factors)) == Int
-        @test valtype(factors) == Int
-        @test valtype(typeof(factors)) == Int
-    end
+    @test keytype(factors) == Int
+    @test keytype(typeof(factors)) == Int
+    @test valtype(factors) == Int
+    @test valtype(typeof(factors)) == Int
 
     push_test!(factors, 70,3)
     @test length(factors) == len+1
@@ -1635,10 +1601,8 @@ function test8()
     @test !haskey(m,0.5)
     @test eltype(m) == Float64
     @test eltype(typeof(m)) == Float64
-    if VERSION >= v"0.4.0-dev"
-        @test keytype(m) == Float64
-        @test keytype(typeof(m)) == Float64
-    end
+    @test keytype(m) == Float64
+    @test keytype(typeof(m)) == Float64
     @test orderobject(m) == Forward
     pop!(m, smallest)
     checkcorrectness(m.bt, false)
@@ -1704,60 +1668,35 @@ end
                
 
 # test the constructors of SortedDict and SortedMultiDict
-if VERSION >= v"0.4.0-dev"
 
-    function test9()
+function test9()
 
-        sd1 = SortedDict("w" => 64, "p" => 12)
-        @test length(sd1) == 2 && first(sd1) == ("p"=>12) &&
-            last(sd1) == ("w"=>64)
-        sd2 = SortedDict(Reverse, "w" => 64, "p" => 12)
-        @test length(sd2) == 2 && last(sd2) == ("p"=>12) &&
-            first(sd2) == ("w"=>64)
-        sd3 = SortedDict(("w"=>64, "p"=>12))
-        @test length(sd3) == 2 && first(sd3) == ("p"=>12) &&
-            last(sd3) == ("w"=>64)
-        sd4 = SortedDict(("w"=>64, "p"=>12), Reverse)
-        @test length(sd4) == 2 && last(sd4) == ("p"=>12) &&
-            first(sd4) == ("w"=>64)
-        sm1 = SortedMultiDict("w" => 64, "p" => 12, "p" => 9)
-        @test length(sm1) == 3 && first(sm1) == ("p"=>12) &&
-            last(sm1) == ("w"=>64)
-        sm2 = SortedMultiDict(Reverse, "w" => 64, "p" => 12, "p" => 9)
-        @test length(sm2) == 3 && last(sm2) == ("p"=>9) &&
-            first(sm2) == ("w"=>64)
-        sm3 = SortedMultiDict(("w"=>64, "p"=>12, "p"=> 9))
-        @test length(sm3) == 3 && first(sm3) == ("p"=>12) &&
-            last(sm3) == ("w"=>64)
-        sm4 = SortedMultiDict(("w"=> 64, "p"=>12, "p"=>9), Reverse)
-        @test length(sm4) == 3 && last(sm4) == ("p"=>9) &&
-            first(sm4) == ("w"=>64)
-        nothing
-    end
-else
-    function test9()
-        sd1 = SortedDict(["w", "p"], [64,12])
-        @test length(sd1) == 2 && first(sd1) == ("p",12) &&
-            last(sd1) == ("w",64)
-        sd2 = SortedDict(["w", "p"], [64,12], Reverse)
-        @test length(sd2) == 2 && last(sd2) == ("p",12) &&
-            first(sd2) == ("w",64)
-        sd3 = SortedDict([("w",64), ("p",12)])
-        @test length(sd3) == 2 && first(sd3) == ("p",12) &&
-            last(sd3) == ("w",64)
-        sd4 = SortedDict([("w", 64), ("p",12)], Reverse)
-        @test length(sd4) == 2 && last(sd4) == ("p",12) &&
-            first(sd4) == ("w",64)
-        sm3 = SortedMultiDict([("w",64), ("p",12), ("p", 9)])
-        @test length(sm3) == 3 && first(sm3) == ("p",12) &&
-            last(sm3) == ("w",64)
-        sm4 = SortedMultiDict([("w", 64), ("p",12), ("p", 9)], Reverse)
-        @test length(sm4) == 3 && last(sm4) == ("p",9) &&
-            first(sm4) == ("w",64)
-        nothing
-    end
+    sd1 = SortedDict("w" => 64, "p" => 12)
+    @test length(sd1) == 2 && first(sd1) == ("p"=>12) &&
+        last(sd1) == ("w"=>64)
+    sd2 = SortedDict(Reverse, "w" => 64, "p" => 12)
+    @test length(sd2) == 2 && last(sd2) == ("p"=>12) &&
+        first(sd2) == ("w"=>64)
+    sd3 = SortedDict(("w"=>64, "p"=>12))
+    @test length(sd3) == 2 && first(sd3) == ("p"=>12) &&
+        last(sd3) == ("w"=>64)
+    sd4 = SortedDict(("w"=>64, "p"=>12), Reverse)
+    @test length(sd4) == 2 && last(sd4) == ("p"=>12) &&
+        first(sd4) == ("w"=>64)
+    sm1 = SortedMultiDict("w" => 64, "p" => 12, "p" => 9)
+    @test length(sm1) == 3 && first(sm1) == ("p"=>12) &&
+        last(sm1) == ("w"=>64)
+    sm2 = SortedMultiDict(Reverse, "w" => 64, "p" => 12, "p" => 9)
+    @test length(sm2) == 3 && last(sm2) == ("p"=>9) &&
+        first(sm2) == ("w"=>64)
+    sm3 = SortedMultiDict(("w"=>64, "p"=>12, "p"=> 9))
+    @test length(sm3) == 3 && first(sm3) == ("p"=>12) &&
+        last(sm3) == ("w"=>64)
+    sm4 = SortedMultiDict(("w"=> 64, "p"=>12, "p"=>9), Reverse)
+    @test length(sm4) == 3 && last(sm4) == ("p"=>9) &&
+        first(sm4) == ("w"=>64)
+    nothing
 end
-
 
 
 test1()


### PR DESCRIPTION
@simonster is preparing to drop Julia 0.3 support for DataStructures.jl. This PR remove references to 0.3 from the portions of src, readme and test files that pertain to sorted containers. 