### PR TITLE
[RFC] deque(T) == deque(T) returns false

### DIFF
--- a/src/deque.jl
+++ b/src/deque.jl
@@ -90,6 +90,29 @@ function back(q::Deque)
 end
 
 
+# Equality
+
+function ==(x::Deque, y::Deque ; front::Bool = true)
+    xcopy = deepcopy(x)
+    ycopy = deepcopy(y)
+    front ? _equals_shift!(xcopy, ycopy) : _equals_pop!(xcopy, ycopy)
+end
+
+function _equals_pop!(x::Deque, y::Deque)
+    isempty(x) && return isempty(y)
+    isempty(y) && return false
+    isequal(pop!(x), pop!(y)) || return false
+    isequal_pop!(x, y)
+end
+
+function _equals_shift!(x::Deque, y::Deque)
+    isempty(x) && return isempty(y)
+    isempty(y) && return false
+    isequal(shift!(x), shift!(y)) || return false
+    isequal_shift!(x, y)
+end
+
+
 # Iteration
 
 immutable DequeIterator{T}


### PR DESCRIPTION
After #135 (fixed by #136) about `LinkedList`s, I stumbled again on the equality problem again with `Deque`s.
```julia
a = deque(Int)
b = deque(Int)
a == b # returns false, should return true
push!(a, 2)
push!(b, 2)
a == b # returns false, should return true
```
The reason is that `==` falls back to `===` since it is not explicitly implemented (much like #135).
So this PR suggests a fix. 
Note that, with this implementation, empty deques are considered equal even if their eltypes are different. In other words: `deque(T) == deque(S)`. This is consistent with arrays, where `T[] == S[]`.
I have written two recursive implementations, one for each deque traversing direction: `pop!` and `shift!`.

Tests are not included. I will add some if you agree with the idea.