### PR TITLE
Remove support for v0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - linux
     - osx
 julia: 
-    - 0.3
     - 0.4
     - nightly
 notifications:

--- a/README.rst
+++ b/README.rst
@@ -483,13 +483,9 @@ Constructors for Sorted Containers
 
 ``SortedDict(d)``
   Argument ``d`` is an ordinary Julia dict (or any associative type)
-  used to initialize the container, e.g., for Julia 0.4/0.5::
+  used to initialize the container::
 
      c = SortedDict(Dict("New York" => 1788, "Illinois" => 1818))
-
-  or for 0.3::
-
-     c = SortedDict(["New York" => 1788, "Illinois" => 1818])
 
 
   In this example the key-type is deduced to be ASCIIString, while the
@@ -505,40 +501,29 @@ Constructors for Sorted Containers
   Arguments are key-value pairs for insertion into the 
   dictionary.  
   The keys must be of the same type as one another; the
-  values must also be of one type.  (Julia 0.4/0.5 only.)
+  values must also be of one type. 
 
 ``SortedDict(o, k1=>v1, k2=>v2, ...)``
   The first argument ``o`` is an ordering object.  The remaining
   arguments are key-value pairs for insertion into the 
   dictionary.  
   The keys must be of the same type as one another; the
-  values must also be of one type. (Julia 0.4/0.5 only.)
+  values must also be of one type. 
 
 ``SortedDict(iter)``
   Takes an arbitrary iterable object of key=>value pairs.
-  The default Forward ordering is used.  In Julia 0.3,
-  the ``iter`` argument must be an ``AbstractArray`` of
-  key-value two-entry tuples.
+  The default Forward ordering is used.  
 
 ``SortedDict(iter,o)``
   Takes an arbitrary iterable object of key=>value pairs.
-  The ordering object ``o`` is explicitly given.  In Julia 0.3,
-  the ``iter`` argument must be an ``AbstractArray`` of
-  key-value two-entry tuples.
+  The ordering object ``o`` is explicitly given.  
 
 ``SortedDict{K,V,Ord}(o)``
   Construct an empty SortedDict in which type parameters
   are explicitly listed; ordering object is explicitly specified.
   (See below for discussion of ordering.)  An empty SortedDict
   may also be constructed using ``SortedDict(Dict{K,V}(),o)`` 
-  in Julia 0.4/0.5, where the ``o`` argument is optional, or 
-  ``SortedDict((K=>V)[],o)`` in Julia 0.3.
-
-``SortedDict(ks,vs,o)``
-  Here, ``ks`` is an array of keys, ``vs`` is an array of values
-  of the same length, and ``o`` is the optional ordering argument.
-  This syntax is available in Julia 0.3 only.  In Julia 0.4/0.5,
-  use ``SortedDict(zip(ks,vs),o).``
+  where the ``o`` argument is optional.
 
 ``SortedMultiDict(ks,vs,o)``
   Construct a SortedMultiDict using keys given by ``ks``, values
@@ -552,7 +537,7 @@ Constructors for Sorted Containers
   Arguments are key-value pairs for insertion into the 
   multidict.  
   The keys must be of the same type as one another; the
-  values must also be of one type.  Julia 0.4/0.5 only.
+  values must also be of one type. 
 
 
 ``SortedMultiDict(o, k1=>v1, k2=>v2, ...)``
@@ -560,21 +545,16 @@ Constructors for Sorted Containers
   arguments are key-value pairs for insertion into the 
   multidict.
   The keys must be of the same type as one another; the
-  values must also be of one type. Julia 0.4/0.5 only.
+  values must also be of one type.
 
 
 ``SortedMultiDict(iter)``
   Takes an arbitrary iterable object of key=>value pairs.
-  The default Forward ordering is used.  In Julia 0.3, 
-  the ``iter`` argument must be an ``AbstractArray``
-  of (key,value) tuples.
+  The default Forward ordering is used. 
 
 ``SortedMultiDict(iter,o)``
   Takes an arbitrary iterable object of key=>value pairs.
   The ordering object ``o`` is explicitly given.
-  In Julia 0.3, 
-  the ``iter`` argument must be an ``AbstractArray``
-  of (key,value) tuples.
 
 
 ``SortedMultiDict{K,V,Ord}(o)``
@@ -633,10 +613,9 @@ Navigating the Containers
   is a token (i.e., ``sc`` is a container and ``st`` is a semitoken).
   Note the double-parentheses in the calling syntax: the argument of ``deref``
   is  a token, which is defined to be a 2-tuple.
-  This returns the (key, value) 2-entry tuple in Julia 0.3 and a key=>value
-  pair in Julia 0.4/0.5
+  This returns a key=>value pair.
   pointed to by the token for SortedDict and SortedMultiDict.  
-  Note that in any one of Julia 0.3/0.4/0.5, the syntax
+  Note that the syntax
   ``k,v=deref((sc,st))`` is valid because Julia automatically iterates
   over the two entries of the Pair in order to assign ``k`` and ``v``.
   For SortedSet this returns a key.  Time: O(1)
@@ -671,8 +650,7 @@ Navigating the Containers
 
 ``first(sc)``
   Argument ``sc`` is a SortedDict, SortedMultiDict or SortedSet  This function
-  returns the first item (a ``k=>v`` pair for SortedDict and SortedMultiDict in 
-  Julia 0.4/0.5 or a ``(k,v)`` tuple in Julia 0.3;
+  returns the first item (a ``k=>v`` pair for SortedDict and SortedMultiDict or
   a key for SortedSet)
   according
   to the sorted order in the container.  Thus, ``first(sc)`` is
@@ -682,9 +660,8 @@ Navigating the Containers
 
 ``last(sc)``
   Argument ``sc`` is a SortedDict, SortedMultiDict or SortedSet.  This function
-  returns the last item (a ``k=>v`` pair for SortedDict and SortedMultiDict in
-  Julia 0.4/0.5 or a ``(k,v)`` tuple in Julia 0.3; 
-  a key for SortedSet)
+  returns the last item (a ``k=>v`` pair for SortedDict and SortedMultiDict
+  or   a key for SortedSet)
   according
   to the sorted order in the container.  Thus, ``last(sc)`` is
   equivalent to ``deref((sc,endof(sc)))``.
@@ -811,8 +788,7 @@ Inserting & Deleting in Sorted Containers
   this overwrites
   the old value. 
   The return
-  value is ``sc``.  In Julia 0.3, the syntax for this call
-  is ``push!(sc, k, v)``.
+  value is ``sc``. 
   Time: O(*c* log *n*)
 
 
@@ -926,8 +902,7 @@ the sort order of the key.  If one uses::
   end
 
 where ``sc`` is a SortedDict or SortedMultiDict, then ``p`` is
-a ``k=>v`` pair in Julia 0.4/0.5 or a ``(k,v)`` tuple in Julia 0.3.
-
+a ``k=>v`` pair.
 
 For SortedSet one uses::
 
@@ -966,9 +941,7 @@ In this setting, either or both can be the past-end token, and ``(sc,st2)`` can
 be the before-start token. For the sake
 of consistency, ``exclusive`` also supports the calling format
 ``exclusive(sc,(st1,st2))``.  In the previous few snippets, if the loop
-object is ``p`` instead of ``(k,v)``, then ``p`` is a ``k=>v`` pair in Julia
-0.4/0.5 and a ``(k,v)`` tuple in Julia 0.3.
-
+object is ``p`` instead of ``(k,v)``, then ``p`` is a ``k=>v`` pair.
 
 
 Both the ``inclusive`` and ``exclusive`` functions return objects that can be 
@@ -1028,11 +1001,10 @@ If one wishes to retrieve only semitokens, the following may be used::
        < body >
    end
 
-   
 
 In this case, ``sc`` is a SortedDict, SortedMultiDict, or SortedSet.
 To be compatible with standard containers, the package also offers
-``eachindex`` iteration (Julia 0.4/0.5 only)::
+``eachindex`` iteration::
 
 
    for ind in eachindex(sc)
@@ -1073,8 +1045,8 @@ Other Functions
 ``in(p,sc)``
   Returns true if ``p`` is in ``sc``.  In the
   case that ``sc`` is a SortedDict or SortedMultiDict,
-  ``p`` is a (key,value) tuple in Julia 0.3 or a key=>value
-  pair in Julia 0.4/0.5.  In the case that ``sc``
+  ``p`` is a key=>value
+  pair.  In the case that ``sc``
   is a SortedSet, ``p`` should be a key.
   Time: O(*c* log *n*) for SortedDict and SortedSet.
   In the case of SortedMultiDict, the time is
@@ -1099,8 +1071,7 @@ Other Functions
   semitokens, ``k`` is a key, and ``v`` is a value, will
   loop over all entries in the dictionary between
   the two tokens and a compare for equality using ``isequal`` between the
-  indexed item and ``k=>v``.  (In Julia 0.3, the syntax would be
-  ``(k,v) in exclusive(sd, st1, st2)``.)
+  indexed item and ``k=>v``.
 
   The five exceptions are::
 
@@ -1112,7 +1083,6 @@ Other Functions
 
   Here, ``sd`` is a SortedDict,
   ``smd`` is a SortedMultiDict, and ``ss`` is a SortedSet.
-  In the first two items, one uses ``(k,v)`` for Julia 0.3 rather than ``k=>v``.
 
   These five invocations of ``in``
   use the index structure
@@ -1134,8 +1104,7 @@ Other Functions
 
 
 ``eltype(sc)``
-  Returns the (key,value) type (a 2-entry pair, i.e., ``Pair{K,V}`` in
-  Julia 0.4/0.5; a 2-tuple type ``(K,V)`` in Julia 0.3)
+  Returns the (key,value) type (a 2-entry pair, i.e., ``Pair{K,V}``)
   for SortedDict and SortedMultiDict.
   Returns the key type for SortedSet.  This function may
   also be applied to the type itself.
@@ -1145,7 +1114,7 @@ Other Functions
   Returns the key type 
   for SortedDict, SortedMultiDict and SortedSet.
   This function may
-  also be applied to the type itself.  Julia 0.4/0.5 only.
+  also be applied to the type itself. 
   Time: O(1)
 
 
@@ -1153,10 +1122,8 @@ Other Functions
   Returns the value type 
   for SortedDict and SortedMultiDict.
   This function may
-  also be applied to the type itself. Julia 0.4/0.5 only.
+  also be applied to the type itself.
   Time: O(1)
-
-
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -277,8 +277,8 @@ Examples using ``DefaultDict``::
   dd = DefaultDict(()->myfunc())    # call function myfunc to provide the default value
 
   # These all create the same default dict
-  dd = @compat DefaultDict(AbstractString, Vector{Int},        # Vector{Int}() is Julia v0.4 notation
-                           () -> Vector{Int}())        # @compat allows it to be used on v0.3
+  dd = DefaultDict(AbstractString, Vector{Int},
+                           () -> Vector{Int}())
   dd = DefaultDict(AbstractString, Vector{Int}, () -> Int[])
 
   # dd = DefaultDict(AbstractString, Vector{Int},     # **Note! Julia v0.4 and later only!
@@ -389,7 +389,7 @@ Finally, SortedMultiDict is similar to SortedDict except that each key
 can be associated with multiple values.  The key=>value pairs in
 a SortedMultiDict are stored according to the sorted order for keys,
 and key=>value pairs with the same
-key are stored in order of insertion. 
+key are stored in order of insertion.
 
 The containers internally use a 2-3 tree, which is a
 kind of balanced tree and is described in many elementary data
@@ -407,7 +407,7 @@ More details are provided below.
 Tokens for Sorted Containers
 ------------------------------
 
-The sorted container objects use a special type for indexing 
+The sorted container objects use a special type for indexing
 called a *token*
 defined as a two-entry tuple and aliased as
 ``SDToken``, ``SMDToken``, and ``SetToken`` for SortedDict, SortedMultiDict
@@ -424,7 +424,7 @@ and SortedSet.  These types are
 all aliases of ``IntSemiToken``.
 
 A restriction for the sorted containers is that
-``IntSemiToken`` or its aliases cannot used as the key-type.  
+``IntSemiToken`` or its aliases cannot used as the key-type.
 This is because
 ambiguity would result between the
 two subscripting calls ``sc[k]`` and ``sc[st]`` described below.  In the
@@ -440,7 +440,7 @@ For example, the first entry of a token is a pointer to a container
 (a non-bits type), so
 a new token is allocated on the heap rather than the
 stack.  In order to avoid performance loss, the package uses tokens
-less frequently than semitokens.  For a function 
+less frequently than semitokens.  For a function
 taking a token as an argument like
 ``deref`` described below, if it is invoked by explicitly naming
 the token like this::
@@ -462,16 +462,16 @@ Tokens can be explicitly advanced or regressed through the data in
 the sorted order; they are implicitly advanced or regressed via
 iteration loops defined below.
 
-A token may take two 
+A token may take two
 special values:
 the *before-start* value and the *past-end* value.  These
 values act as lower and upper bounds
 on the actual data.  The before-start token can be advanced,
 while the past-end token can be regressed.  A dereferencing operation on either
-leads to an error.  
+leads to an error.
 
 In the current implementation,
-semitokens are internally stored as integers. However, 
+semitokens are internally stored as integers. However,
 for the purpose of future compatibility,
 the user should  not extract this internal representation;
 these integers do not have a documented interpretation
@@ -495,54 +495,54 @@ Constructors for Sorted Containers
 ``SortedDict(d,o)``
   Argument ``d`` is an ordinary Julia dict (or any associative type)
   used to initialize the container and ``o`` is an ordering object
-  used for ordering the keys. 
+  used for ordering the keys.
 
 ``SortedDict(k1=>v1, k2=>v2, ...)``
-  Arguments are key-value pairs for insertion into the 
-  dictionary.  
+  Arguments are key-value pairs for insertion into the
+  dictionary.
   The keys must be of the same type as one another; the
-  values must also be of one type. 
+  values must also be of one type.
 
 ``SortedDict(o, k1=>v1, k2=>v2, ...)``
   The first argument ``o`` is an ordering object.  The remaining
-  arguments are key-value pairs for insertion into the 
-  dictionary.  
+  arguments are key-value pairs for insertion into the
+  dictionary.
   The keys must be of the same type as one another; the
-  values must also be of one type. 
+  values must also be of one type.
 
 ``SortedDict(iter)``
   Takes an arbitrary iterable object of key=>value pairs.
-  The default Forward ordering is used.  
+  The default Forward ordering is used.
 
 ``SortedDict(iter,o)``
   Takes an arbitrary iterable object of key=>value pairs.
-  The ordering object ``o`` is explicitly given.  
+  The ordering object ``o`` is explicitly given.
 
 ``SortedDict{K,V,Ord}(o)``
   Construct an empty SortedDict in which type parameters
   are explicitly listed; ordering object is explicitly specified.
   (See below for discussion of ordering.)  An empty SortedDict
-  may also be constructed using ``SortedDict(Dict{K,V}(),o)`` 
+  may also be constructed using ``SortedDict(Dict{K,V}(),o)``
   where the ``o`` argument is optional.
 
 ``SortedMultiDict(ks,vs,o)``
   Construct a SortedMultiDict using keys given by ``ks``, values
   given by ``vs`` and ordering object ``o``.  The ordering object
   defaults to ``Forward`` if not specified.  The two arguments
-  ``ks`` and ``vs`` are 1-dimensional arrays of the same length in 
+  ``ks`` and ``vs`` are 1-dimensional arrays of the same length in
   which ``ks`` holds keys and ``vs`` holds the corresponding values.
 
 
 ``SortedMultiDict(k1=>v1, k2=>v2, ...)``
-  Arguments are key-value pairs for insertion into the 
-  multidict.  
+  Arguments are key-value pairs for insertion into the
+  multidict.
   The keys must be of the same type as one another; the
-  values must also be of one type. 
+  values must also be of one type.
 
 
 ``SortedMultiDict(o, k1=>v1, k2=>v2, ...)``
   The first argument ``o`` is an ordering object.  The remaining
-  arguments are key-value pairs for insertion into the 
+  arguments are key-value pairs for insertion into the
   multidict.
   The keys must be of the same type as one another; the
   values must also be of one type.
@@ -550,7 +550,7 @@ Constructors for Sorted Containers
 
 ``SortedMultiDict(iter)``
   Takes an arbitrary iterable object of key=>value pairs.
-  The default Forward ordering is used. 
+  The default Forward ordering is used.
 
 ``SortedMultiDict(iter,o)``
   Takes an arbitrary iterable object of key=>value pairs.
@@ -568,7 +568,7 @@ Constructors for Sorted Containers
   Construct a SortedSet using keys given by iterable ``iter`` (e.g.,
   an array)
   and ordering object ``o``.  The ordering object
-  defaults to ``Forward`` if not specified.  
+  defaults to ``Forward`` if not specified.
 
 ``SortedSet{K,Ord}(o)``
   Construct an empty sorted set in which type parameter
@@ -586,16 +586,16 @@ Complexity of Sorted Containers
 
 In the list of functions below, the running time of the various
 operations is provided.  In these running times,
-*n* denotes the current size 
+*n* denotes the current size
 (number of items) in the
 container at the time of the function call, and *c* denotes the
 time needed to compare two keys.
 
 --------------------------------------
-Navigating the Containers 
+Navigating the Containers
 --------------------------------------
 ``sd[k]``
-  Argument ``sd`` is a SortedDict and ``k`` is a key.  In an 
+  Argument ``sd`` is a SortedDict and ``k`` is a key.  In an
   expression, this retrieves the value associated with the key
   (or ``KeyError`` if none).  On the left-hand side of an
   assignment, this assigns or
@@ -605,7 +605,7 @@ Navigating the Containers
 ``find(sd,k)``
   Argument ``sd`` is a SortedDict and argument ``k`` is a key.
   This function returns the semitoken that refers to the item whose key
-  is ``k``, or 
+  is ``k``, or
   past-end semitoken if ``k`` is absent. Time: O(*c* log *n*)
 
 ``deref((sc,st))``
@@ -614,7 +614,7 @@ Navigating the Containers
   Note the double-parentheses in the calling syntax: the argument of ``deref``
   is  a token, which is defined to be a 2-tuple.
   This returns a key=>value pair.
-  pointed to by the token for SortedDict and SortedMultiDict.  
+  pointed to by the token for SortedDict and SortedMultiDict.
   Note that the syntax
   ``k,v=deref((sc,st))`` is valid because Julia automatically iterates
   over the two entries of the Pair in order to assign ``k`` and ``v``.
@@ -622,15 +622,15 @@ Navigating the Containers
 
 
 ``deref_key((sc,st))``
-  Argument ``(sc,st)`` is a token for SortedMultiDict or SortedDict.  
-  This returns the key (i.e., the first half of a key=>value pair) 
+  Argument ``(sc,st)`` is a token for SortedMultiDict or SortedDict.
+  This returns the key (i.e., the first half of a key=>value pair)
   pointed to by the token.  This functionality is available as plain ``deref``
   for SortedSet.
   Time: O(1)
 
 
 ``deref_value((sc,st))``
-  Argument ``(sc,st)`` is a token for SortedMultiDict or SortedDict.  
+  Argument ``(sc,st)`` is a token for SortedMultiDict or SortedDict.
   This returns the value (i.e., the second half of a key=>value pair)
   pointed to by the token.
   Time: O(1)
@@ -688,14 +688,14 @@ Navigating the Containers
 
 
 ``regress((sc,st))``
-  Argument 
+  Argument
   ``(sc,st)`` is a token.  This function returns the semitoken of the
   previous entry in the container according to the sort order of the
   keys.  If ``(sc,st)`` indexes the first item, this routine returns the before-start
   semitoken.  It is an error to invoke this function if ``(sc,st)`` is the
   before-start token.  If ``(sc,st)`` is the past-end token, then this
   routine returns the smitoken of the last item in the sort order (i.e., the
-  same semitoken returned by the ``endof`` function).  
+  same semitoken returned by the ``endof`` function).
   Time: O(log *n*)
 
 ``searchsortedfirst(sc,k)``
@@ -726,14 +726,14 @@ Navigating the Containers
 
 ``searchequalrange(sc,k)``
    Argument ``sc`` is a SortedMultiDict and ``k`` is an element of the
-   key type.  This routine returns a pair of semitokens; the first 
+   key type.  This routine returns a pair of semitokens; the first
    of the pair is the semitoken addressing the first item in the container
    with key ``k`` and the second is the semitoken addressing the
    last item in the container with key ``k``.  If no item matches
    the given key, then the pair (past-end-semitoken, before-start-semitoken)
    is returned.
    Time: O(*c* log *n*)
-   
+
 --------------------------------------------
 Inserting & Deleting in Sorted Containers
 --------------------------------------------
@@ -761,12 +761,12 @@ Inserting & Deleting in Sorted Containers
   This inserts the key into
   the container.  If the key is already present in a
   this overwrites
-  the old value.  (This is not necessarily a no-op; see below for 
+  the old value.  (This is not necessarily a no-op; see below for
   remarks about the customizing the sort order.)
   The return
   value is a pair whose first entry is boolean and indicates whether
   the insertion was new (i.e., the key was not previously present) and
-  the second entry is the semitoken of the new entry. 
+  the second entry is the semitoken of the new entry.
   Time: O(*c* log *n*)
 
 ``push!(sc,k)``
@@ -774,21 +774,21 @@ Inserting & Deleting in Sorted Containers
   This inserts the key into
   the container.  If the key is already present in a
   this overwrites
-  the old value.  (This is not necessarily a no-op; see below for 
+  the old value.  (This is not necessarily a no-op; see below for
   remarks about the customizing the sort order.)
   The return
   value is ``sc``.
   Time: O(*c* log *n*)
 
 ``push!(sc, k=>v)``
-  Argument ``sc`` is a SortedDict or SortedMultiDict and ``k=>v`` is a 
+  Argument ``sc`` is a SortedDict or SortedMultiDict and ``k=>v`` is a
   key-value pair.
   This inserts the key-value pair into
   the container.  If the key is already present in a
   this overwrites
-  the old value. 
+  the old value.
   The return
-  value is ``sc``. 
+  value is ``sc``.
   Time: O(*c* log *n*)
 
 
@@ -798,7 +798,7 @@ Inserting & Deleting in Sorted Containers
   This operation deletes the item addressed by ``(sc,st)``.
   It is an error to call
   this on an entry that has already been deleted or on the
-  before-start or past-end tokens.  After this operation is 
+  before-start or past-end tokens.  After this operation is
   complete, ``(sc,st)`` is an invalid token and cannot be used in
   any further operations.
   Time: O(log *n*)
@@ -808,14 +808,14 @@ Inserting & Deleting in Sorted Containers
   ``k`` is a key.  This operation deletes the item
   whose key is ``k``.  It is a  ``KeyError``
   if ``k`` is not a key of an item in the container.
-  After this operation is 
+  After this operation is
   complete, any token addressing the deleted item is invalid.
   Returns ``sc``.
   Time: O(*c* log *n*)
 
 
 ``pop!(sc,k)``
-  Deletes the item with key ``k`` in SortedDict or SortedSet ``sc`` 
+  Deletes the item with key ``k`` in SortedDict or SortedSet ``sc``
   and returns
   the value that was associated with ``k`` in the
   case of SortedDict or ``k`` itself in the case of SortedSet.
@@ -833,7 +833,7 @@ Inserting & Deleting in Sorted Containers
   then ``sc[st]`` refers to
   the value field of the (key,value) pair that the full
   token ``(sc,st)`` refers to.  This expression may occur on either side of an
-  assignment statement.  
+  assignment statement.
   Time: O(1)
 
 
@@ -849,9 +849,9 @@ Token Manipulation
   return value is -1 if ``(sc,st1)`` precedes ``(sc,st2)``, 0
   if they are equal, and 1 if ``(sc,st1)`` succeeds ``(sc,st2)``.
   This function compares the tokens by determining their relative
-  position within the tree without dereferencing them.  For 
+  position within the tree without dereferencing them.  For
   SortedDict it is mostly
-  equivalent to comparing ``deref_key((sc,st1))`` to ``deref_key((sc,st2))`` 
+  equivalent to comparing ``deref_key((sc,st1))`` to ``deref_key((sc,st2))``
   using the ordering of the SortedDict
   except in the
   case that either ``(sc,st1)`` or ``(sc,st2)`` is the before-start or past-end token,
@@ -893,8 +893,8 @@ The following snippet loops over the entire container ``sc``, where
      < body >
   end
 
-In this loop, ``(k,v)`` takes on successive (key,value) pairs 
-according to 
+In this loop, ``(k,v)`` takes on successive (key,value) pairs
+according to
 the sort order of the key.  If one uses::
 
   for p in sc
@@ -919,14 +919,14 @@ The first is the inclusive iteration for SortedDict and SortedMultiDict::
   end
 
 Here, ``st1`` and ``st2`` are semitokens that refer to the container ``sc``.
-It is acceptable for ``(sc,st1)`` to be the past-end token 
+It is acceptable for ``(sc,st1)`` to be the past-end token
 or ``(sc,st2)`` to be the before-start token (in these cases, the body
 is not executed).
-If ``compare(sc,st1,st2)==1`` then the body is not executed. 
-A second calling format for ``inclusive`` is 
+If ``compare(sc,st1,st2)==1`` then the body is not executed.
+A second calling format for ``inclusive`` is
 ``inclusive(sc,(st1,st2))``.  One purpose for second format is so that
 the return value of ``searchequalrange`` may be used directly
-as the second argument to ``inclusive``.  
+as the second argument to ``inclusive``.
 
 
 One can also define a loop that excludes the final item::
@@ -944,8 +944,8 @@ of consistency, ``exclusive`` also supports the calling format
 object is ``p`` instead of ``(k,v)``, then ``p`` is a ``k=>v`` pair.
 
 
-Both the ``inclusive`` and ``exclusive`` functions return objects that can be 
-saved and used later for iteration.  
+Both the ``inclusive`` and ``exclusive`` functions return objects that can be
+saved and used later for iteration.
 The validity of the tokens is not checked until the loop initiates.
 
 For SortedSet the usage is::
@@ -970,7 +970,7 @@ one can iterate over just keys or just values::
       < body >
    end
 
-Finally, one can retrieve 
+Finally, one can retrieve
 semitokens during any of these iterations.  In the case
 of SortedDict and SortedMultiDict, one uses::
 
@@ -987,8 +987,8 @@ of SortedDict and SortedMultiDict, one uses::
    end
 
 In each of the above three iterations, ``st`` is a
-semitoken referring to the 
-current ``(k,v)`` pair.  
+semitoken referring to the
+current ``(k,v)`` pair.
 In the case of SortedSet, the following iteration may be used::
 
    for (st,k) in semitokens(ss)
@@ -1062,9 +1062,9 @@ Other Functions
   above in the discussion of container loops and ``x``
   is of the appropriate type.
   For all of the iterables except the five listed below,
-  the algorithm used 
+  the algorithm used
   is a linear-time search.  For example, the call::
-     
+
     (k=>v) in exclusive(sd,st1,st2)
 
   where ``sd`` is a SortedDict, ``st1`` and ``st2`` are
@@ -1111,15 +1111,15 @@ Other Functions
   Time: O(1)
 
 ``keytype(sc)``
-  Returns the key type 
+  Returns the key type
   for SortedDict, SortedMultiDict and SortedSet.
   This function may
-  also be applied to the type itself. 
+  also be applied to the type itself.
   Time: O(1)
 
 
 ``valtype(sc)``
-  Returns the value type 
+  Returns the value type
   for SortedDict and SortedMultiDict.
   This function may
   also be applied to the type itself.
@@ -1128,7 +1128,7 @@ Other Functions
 
 
 ``similar(sc)``
-  Returns a new SortedDict, SortedMultiDict, or SortedSet 
+  Returns a new SortedDict, SortedMultiDict, or SortedSet
   of the same type and with the same ordering
   as ``sc`` but with no entries (i.e., empty).  Time: O(1)
 
@@ -1156,7 +1156,7 @@ Other Functions
 
 ``getkey(sd,k,defaultk)``
   Returns key ``k`` where ``sd`` is a SortedDict, if ``k`` is in ``sd``
-  else it returns ``defaultk``. 
+  else it returns ``defaultk``.
   If the container uses in its ordering
   an ``eq`` method different from
   isequal (e.g., case-insensitive ASCII strings illustrated below), then the
@@ -1180,7 +1180,7 @@ Other Functions
   does not imply any correspondence between semitokens for items
   in ``sc1`` with those for ``sc2``.  If the equality-testing method associated
   with the keys and values implies hash-equivalence in the
-  case of SortedDict, then ``isequal`` of the 
+  case of SortedDict, then ``isequal`` of the
   entire containers implies hash-equivalence of the containers.
   Time: O(*cn* + *n* log *n*)
 
@@ -1189,14 +1189,14 @@ Other Functions
   packed.  When deletions take
   place, the previously allocated memory is not returned.
   This function can be used to reclaim memory after
-  many deletions.  
+  many deletions.
   Time: O(*cn* log *n*)
 
 ``deepcopy(sc)``
   This returns a copy of ``sc`` in which the data is
   deep-copied, i.e., the keys and values are replicated
   if they are mutable types.  A semitoken for the original ``sc``
-  is a valid 
+  is a valid
   semitoken for the copy because this operation preserves the
   relative positions of the data in memory.
   Time O(*maxn*), where *maxn* denotes the maximum size
@@ -1206,7 +1206,7 @@ Other Functions
   This returns a packed copy of ``sc`` in which the keys
   and values are deep-copied.
   This function can be used to reclaim memory after
-  many deletions.  
+  many deletions.
   Time: O(*cn* log *n*)
 
 
@@ -1260,7 +1260,7 @@ message is produced; instead, the built-in default versions of these functions
   inserts each item from ``ss`` and each item from each iterable argument
   into the returned SortedSet.  Time:  O(*cn* log *n*) where *n* is the
   total number of items in all the arguments.
-   
+
 ``intersect(ss, others...)``
   Each argument is a SortedSet with the same key and order type.
   The return variable is a new SortedSet that is the intersection of
@@ -1271,16 +1271,16 @@ message is produced; instead, the built-in default versions of these functions
   The two argument are sorted sets with the same key and order type.  This operation
   computes the symmetric difference, i.e., a sorted set containing
   entries that are in one of
-  ``ss1``, ``ss2`` but not both.  
+  ``ss1``, ``ss2`` but not both.
   Time: O(*cn* log *n*), where *n* is the
-  total size of the two containers.  
+  total size of the two containers.
 
 ``setdiff(ss1, ss2)``
   The two arguments are sorted sets with the same key and order type.  This operation
   computes the difference, i.e., a sorted set containing entries that in
-  are in ``ss1`` but not ``ss2``.  
+  are in ``ss1`` but not ``ss2``.
   Time: O(*cn* log *n*), where *n* is the
-  total size of the two containers.  
+  total size of the two containers.
 
 ``setdiff!(ss, iterable)``
   This function deletes items in ``ss`` that appear in the second argument.
@@ -1299,7 +1299,7 @@ message is produced; instead, the built-in default versions of these functions
 ----------------------
 Ordering of keys
 ----------------------
-As mentioned earlier, the default ordering of keys uses 
+As mentioned earlier, the default ordering of keys uses
 ``isless`` and ``isequal`` functions.  If the default ordering is used,
 it is a requirement of the container that ``isequal(a,b)`` is true if and
 only if ``!isless(a,b)`` and ``!isless(b,a)`` are both true.  This relationship
@@ -1312,7 +1312,7 @@ The name for the default ordering (i.e., using ``isless`` and
 ``isequal``) is ``Forward``.  Note: this is the name of the
 ordering object; its type is ``ForwardOrdering.``
 Another possible
-ordering object is ``Reverse``, which reverses the usual sorted order.  
+ordering object is ``Reverse``, which reverses the usual sorted order.
 This name must be
 imported ``import Base.Reverse`` if it is used.
 
@@ -1345,7 +1345,7 @@ First, the user creates a singleton type that is a subtype of
     immutable CaseInsensitive <: Ordering
     end
 
-Next, the user defines a method named ``lt`` for less-than 
+Next, the user defines a method named ``lt`` for less-than
 in this ordering::
 
     lt(::CaseInsensitive, a, b) = isless(lowercase(a), lowercase(b))
@@ -1356,7 +1356,7 @@ The container also needs an equal-to function; the default is::
 
     eq(o::Ordering, a, b) = !lt(o, a, b) && !lt(o, b, a)
 
-For a further slight performance boost, the user can also customize 
+For a further slight performance boost, the user can also customize
 this function with a more efficient
 implementation.  In the above example, an appropriate customization would
 be::
@@ -1380,7 +1380,7 @@ Cautionary note on mutable keys
 As with ordinary Dicts, keys for the sorted containers
 can be either mutable or immutable.  In the
 case of mutable keys, it is important that the keys not be mutated
-once they are in the container else the indexing structure will be 
+once they are in the container else the indexing structure will be
 corrupted. (The same restriction applies to Dict.)
 For example, suppose a SortedDict ``sd`` is defined in which the
 keys are of type ``Array{Int,1}.``  (For this to be possible, the user

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,1 @@
-julia 0.3
-Compat 0.7.1
-Docile
+julia 0.4

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -2,8 +2,6 @@ VERSION >= v"0.4.0-dev+6521" && __precompile__()
 
 module DataStructures
 
-    using Compat
-
     import Base: <, <=, ==, length, isempty, start, next, done,
                  show, dump, empty!, getindex, setindex!, get, get!,
                  in, haskey, keys, merge, copy, cat,

--- a/src/containerloops.jl
+++ b/src/containerloops.jl
@@ -259,21 +259,12 @@ end
 
 
 
-if VERSION >= v"0.4.0-dev"
 
 @inline function next(u::SDMIterableTypesBase, state::SAIterationState)
     dt, t, ni = nexthelper(u, state)
     (dt.k => dt.d), ni
 end
 
-else 
-
-@inline function next(u::SDMIterableTypesBase, state::SAIterationState)
-    dt, t, ni = nexthelper(u, state)
-    (dt.k, dt.d), ni
-end
-
-end
 
 @inline function next(u::SSIterableTypesBase, state::SAIterationState)
     dt, t, ni = nexthelper(u, state)
@@ -326,14 +317,6 @@ eachindex{K,D,Ord <: Ordering}(sd::SDMIncludeLast{SortedDict{K,D,Ord}}) = keys(s
 eachindex{K,D,Ord <: Ordering}(smd::SDMIncludeLast{SortedMultiDict{K,D,Ord}}) = 
      onlysemitokens(smd)
 eachindex(ss::SSIncludeLast) = onlysemitokens(ss)
-
-
-
-
-
-
-
-
 
 
 empty!(m::SAContainer) =  empty!(m.bt)

--- a/src/containerloops.jl
+++ b/src/containerloops.jl
@@ -42,7 +42,7 @@ abstract AbstractIncludeLast{ContainerType <: SAContainer}
 
 
 
-immutable SDMIncludeLast{ContainerType <: SDMContainer} <: 
+immutable SDMIncludeLast{ContainerType <: SDMContainer} <:
                                AbstractIncludeLast{ContainerType}
     m::ContainerType
     first::Int
@@ -50,7 +50,7 @@ immutable SDMIncludeLast{ContainerType <: SDMContainer} <:
 end
 
 
-immutable SSIncludeLast{ContainerType <: SortedSet} <: 
+immutable SSIncludeLast{ContainerType <: SortedSet} <:
                                AbstractIncludeLast{ContainerType}
     m::ContainerType
     first::Int
@@ -64,16 +64,16 @@ eltype(s::AbstractIncludeLast) = eltype(s.m)
 ## The basic iterations are either over the whole sorted container, an
 ## exclude-last object or include-last object.
 
-@compat typealias SDMIterableTypesBase Union{SDMContainer,
+typealias SDMIterableTypesBase Union{SDMContainer,
                                      SDMExcludeLast,
                                      SDMIncludeLast}
 
-@compat typealias SSIterableTypesBase Union{SortedSet,
+typealias SSIterableTypesBase Union{SortedSet,
                                     SSExcludeLast,
                                     SSIncludeLast}
 
 
-@compat typealias SAIterableTypesBase Union{SAContainer,
+typealias SAIterableTypesBase Union{SAContainer,
                                     AbstractExcludeLast,
                                     AbstractIncludeLast}
 
@@ -102,7 +102,7 @@ immutable SDMSemiTokenIteration{T <: SDMIterableTypesBase}
     base::T
 end
 
-eltype(s::SDMSemiTokenIteration) = @compat Tuple{IntSemiToken, 
+eltype(s::SDMSemiTokenIteration) = Tuple{IntSemiToken,
                                          keytype(extractcontainer(s.base)),
                                          valtype(extractcontainer(s.base))}
 
@@ -110,7 +110,7 @@ immutable SSSemiTokenIteration{T <: SSIterableTypesBase}
     base::T
 end
 
-eltype(s::SSSemiTokenIteration) = @compat Tuple{IntSemiToken,
+eltype(s::SSSemiTokenIteration) = Tuple{IntSemiToken,
                                         eltype(extractcontainer(s.base))}
 
 
@@ -118,7 +118,7 @@ immutable SDMSemiTokenKeyIteration{T <: SDMIterableTypesBase}
     base::T
 end
 
-eltype(s::SDMSemiTokenKeyIteration) = @compat Tuple{IntSemiToken,
+eltype(s::SDMSemiTokenKeyIteration) = Tuple{IntSemiToken,
                                             keytype(extractcontainer(s.base))}
 
 immutable SAOnlySemiTokensIteration{T <: SAIterableTypesBase}
@@ -132,21 +132,21 @@ immutable SDMSemiTokenValIteration{T <: SDMIterableTypesBase}
     base::T
 end
 
-eltype(s::SDMSemiTokenValIteration) = @compat Tuple{IntSemiToken, 
+eltype(s::SDMSemiTokenValIteration) = Tuple{IntSemiToken,
                                             valtype(extractcontainer(s.base))}
 
-@compat typealias SACompoundIterable Union{SDMKeyIteration,
+typealias SACompoundIterable Union{SDMKeyIteration,
                                    SDMValIteration,
                                    SDMSemiTokenIteration,
                                    SSSemiTokenIteration,
-                                   SDMSemiTokenKeyIteration, 
+                                   SDMSemiTokenKeyIteration,
                                    SDMSemiTokenValIteration,
                                    SAOnlySemiTokensIteration}
 
 @inline extractcontainer(s::SACompoundIterable) = extractcontainer(s.base)
 
 
-@compat typealias SAIterable Union{SAIterableTypesBase, SACompoundIterable}
+typealias SAIterable Union{SAIterableTypesBase, SACompoundIterable}
 
 
 ## All the loops maintain a state which is an object of the
@@ -163,19 +163,19 @@ end
 @inline done(::SAIterable, state::SAIterationState) = state.next == state.final
 
 
-@inline exclusive{T <: SDMContainer}(m::T, ii::(@compat Tuple{IntSemiToken,IntSemiToken})) =
+@inline exclusive{T <: SDMContainer}(m::T, ii::(Tuple{IntSemiToken,IntSemiToken})) =
     SDMExcludeLast(m, ii[1].address, ii[2].address)
 
-@inline exclusive{T <: SortedSet}(m::T, ii::(@compat Tuple{IntSemiToken,IntSemiToken})) =
+@inline exclusive{T <: SortedSet}(m::T, ii::(Tuple{IntSemiToken,IntSemiToken})) =
     SSExcludeLast(m, ii[1].address, ii[2].address)
 
 @inline exclusive{T <: SAContainer}(m::T, i1::IntSemiToken, i2::IntSemiToken) =
     exclusive(m, (i1,i2))
 
-@inline inclusive{T <: SDMContainer}(m::T, ii::(@compat Tuple{IntSemiToken,IntSemiToken})) =
+@inline inclusive{T <: SDMContainer}(m::T, ii::(Tuple{IntSemiToken,IntSemiToken})) =
     SDMIncludeLast(m, ii[1].address, ii[2].address)
 
-@inline inclusive{T <: SortedSet}(m::T, ii::(@compat Tuple{IntSemiToken,IntSemiToken})) =
+@inline inclusive{T <: SortedSet}(m::T, ii::(Tuple{IntSemiToken,IntSemiToken})) =
     SSIncludeLast(m, ii[1].address, ii[2].address)
 
 @inline inclusive{T <: SAContainer}(m::T, i1::IntSemiToken, i2::IntSemiToken) =
@@ -192,19 +192,19 @@ end
 in{K,D,Ord <: Ordering}(k, keyit::SDMKeyIteration{SortedDict{K,D,Ord}}) =
     haskey(extractcontainer(keyit.base), k)
 
-in{K,D,Ord <: Ordering}(k, keyit::SDMKeyIteration{SortedMultiDict{K,D,Ord}}) = 
+in{K,D,Ord <: Ordering}(k, keyit::SDMKeyIteration{SortedMultiDict{K,D,Ord}}) =
     haskey(extractcontainer(keyit.base), k)
 
-    
+
 
 # Next definition needed to break ambiguity with values(Associative) from Dict.jl
 @inline values{K, D, Ord <: Ordering}(ba::SortedDict{K,D,Ord}) = SDMValIteration(ba)
 @inline values{T <: SDMIterableTypesBase}(ba::T) = SDMValIteration(ba)
 @inline semitokens{T <: SDMIterableTypesBase}(ba::T) = SDMSemiTokenIteration(ba)
 @inline semitokens{T <: SSIterableTypesBase}(ba::T) = SSSemiTokenIteration(ba)
-@inline semitokens{T <: SDMIterableTypesBase}(ki::SDMKeyIteration{T}) = 
+@inline semitokens{T <: SDMIterableTypesBase}(ki::SDMKeyIteration{T}) =
                    SDMSemiTokenKeyIteration(ki.base)
-@inline semitokens{T <: SDMIterableTypesBase}(vi::SDMValIteration{T}) = 
+@inline semitokens{T <: SDMIterableTypesBase}(vi::SDMValIteration{T}) =
                    SDMSemiTokenValIteration(vi.base)
 @inline onlysemitokens{T <: SAIterableTypesBase}(ba::T) = SAOnlySemiTokensIteration(ba)
 
@@ -213,23 +213,23 @@ in{K,D,Ord <: Ordering}(k, keyit::SDMKeyIteration{SortedMultiDict{K,D,Ord}}) =
 @inline start(m::SAContainer) = SAIterationState(nextloc0(m.bt,1), 2)
 @inline start(e::SACompoundIterable) = start(e.base)
 
-function start(e::AbstractExcludeLast) 
+function start(e::AbstractExcludeLast)
     (!(e.first in e.m.bt.useddatacells) || e.first == 1 ||
         !(e.pastlast in e.m.bt.useddatacells)) &&
         throw(BoundsError())
     if compareInd(e.m.bt, e.first, e.pastlast) < 0
-        return SAIterationState(e.first, e.pastlast) 
+        return SAIterationState(e.first, e.pastlast)
     else
         return SAIterationState(2, 2)
     end
 end
 
-function start(e::AbstractIncludeLast) 
+function start(e::AbstractIncludeLast)
     (!(e.first in e.m.bt.useddatacells) || e.first == 1 ||
-        !(e.last in e.m.bt.useddatacells) || e.last == 2) && 
+        !(e.last in e.m.bt.useddatacells) || e.last == 2) &&
         throw(BoundsError())
     if compareInd(e.m.bt, e.first, e.last) <= 0
-        return SAIterationState(e.first, nextloc0(e.m.bt, e.last)) 
+        return SAIterationState(e.first, nextloc0(e.m.bt, e.last))
     else
         return SAIterationState(2, 2)
     end
@@ -244,7 +244,7 @@ end
 @inline function next(u::SAOnlySemiTokensIteration, state::SAIterationState)
     sn = state.next
     (sn < 3 || !(sn in extractcontainer(u).bt.useddatacells)) && throw(BoundsError())
-    IntSemiToken(sn), 
+    IntSemiToken(sn),
     SAIterationState(nextloc0(extractcontainer(u).bt, sn), state.final)
 end
 
@@ -252,7 +252,7 @@ end
 @inline function nexthelper(u, state::SAIterationState)
     sn = state.next
     (sn < 3 || !(sn in extractcontainer(u).bt.useddatacells)) && throw(BoundsError())
-    extractcontainer(u).bt.data[sn], sn, 
+    extractcontainer(u).bt.data[sn], sn,
     SAIterationState(nextloc0(extractcontainer(u).bt, sn), state.final)
 end
 
@@ -310,11 +310,11 @@ eachindex(sd::SortedDict) = keys(sd)
 eachindex(sdm::SortedMultiDict) = onlysemitokens(sdm)
 eachindex(ss::SortedSet) = onlysemitokens(ss)
 eachindex{K,D,Ord <: Ordering}(sd::SDMExcludeLast{SortedDict{K,D,Ord}}) = keys(sd)
-eachindex{K,D,Ord <: Ordering}(smd::SDMExcludeLast{SortedMultiDict{K,D,Ord}}) = 
+eachindex{K,D,Ord <: Ordering}(smd::SDMExcludeLast{SortedMultiDict{K,D,Ord}}) =
      onlysemitokens(smd)
 eachindex(ss::SSExcludeLast) = onlysemitokens(ss)
 eachindex{K,D,Ord <: Ordering}(sd::SDMIncludeLast{SortedDict{K,D,Ord}}) = keys(sd)
-eachindex{K,D,Ord <: Ordering}(smd::SDMIncludeLast{SortedMultiDict{K,D,Ord}}) = 
+eachindex{K,D,Ord <: Ordering}(smd::SDMIncludeLast{SortedMultiDict{K,D,Ord}}) =
      onlysemitokens(smd)
 eachindex(ss::SSIncludeLast) = onlysemitokens(ss)
 

--- a/src/defaultdict.jl
+++ b/src/defaultdict.jl
@@ -21,7 +21,7 @@ immutable DefaultDictBase{K,V,F,D} <: Associative{K,V}
     check_D(D,K,V) = (D <: Associative{K,V}) ||
         error("Default dict must be <: Associative{K,V}")
 
-    DefaultDictBase(x::F, kv::AbstractArray{@compat Tuple{K,V}}) = (check_D(D,K,V); new(x, D(kv)))
+    DefaultDictBase(x::F, kv::AbstractArray{Tuple{K,V}}) = (check_D(D,K,V); new(x, D(kv)))
     if VERSION >= v"0.4.0-dev+980"
         DefaultDictBase(x::F, ps::Pair{K,V}...) = (check_D(D,K,V); new(x, D(ps...)))
     end
@@ -44,7 +44,7 @@ DefaultDictBase{F}(default::F,ks,vs) = DefaultDictBase{Any,Any,F,Dict}(default, 
 # syntax entry points
 DefaultDictBase{F}(default::F) = DefaultDictBase{Any,Any,F,Dict}(default)
 DefaultDictBase{K,V,F}(::Type{K}, ::Type{V}, default::F) = DefaultDictBase{K,V,F,Dict}(default)
-DefaultDictBase{K,V,F}(default::F, kv::AbstractArray{@compat Tuple{K,V}}) = DefaultDictBase{K,V,F,Dict}(default, kv)
+DefaultDictBase{K,V,F}(default::F, kv::AbstractArray{Tuple{K,V}}) = DefaultDictBase{K,V,F,Dict}(default, kv)
 
 if VERSION >= v"0.4.0-dev+980"
     DefaultDictBase{K,V,F}(default::F, ps::Pair{K,V}...) = DefaultDictBase{K,V,F,Dict}(default, ps...)
@@ -100,7 +100,7 @@ for (DefaultDict,O) in [(:DefaultDict, :Unordered), (:DefaultOrderedDict, :Order
             if VERSION >= v"0.4.0-dev+980"
                 $DefaultDict(x, ps::Pair{K,V}...) = new(DefaultDictBase{K,V,F,HashDict{K,V,$O}}(x, ps...))
             end
-            $DefaultDict(x, kv::AbstractArray{@compat Tuple{K,V}}) = new(DefaultDictBase{K,V,F,HashDict{K,V,$O}}(x, kv))
+            $DefaultDict(x, kv::AbstractArray{Tuple{K,V}}) = new(DefaultDictBase{K,V,F,HashDict{K,V,$O}}(x, kv))
             $DefaultDict(x, d::$DefaultDict) = $DefaultDict(x, d.d)
             $DefaultDict(x, d::HashDict) = new(DefaultDictBase{K,V,F,HashDict{K,V,$O}}(x, d))
             $DefaultDict(x) = new(DefaultDictBase{K,V,F,HashDict{K,V,$O}}(x))
@@ -119,7 +119,7 @@ for (DefaultDict,O) in [(:DefaultDict, :Unordered), (:DefaultOrderedDict, :Order
         # syntax entry points
         $DefaultDict{F}(default::F) = $DefaultDict{Any,Any,F}(default)
         $DefaultDict{K,V,F}(::Type{K}, ::Type{V}, default::F) = $DefaultDict{K,V,F}(default)
-        $DefaultDict{K,V,F}(default::F, kv::AbstractArray{@compat Tuple{K,V}}) = $DefaultDict{K,V,F}(default, kv)
+        $DefaultDict{K,V,F}(default::F, kv::AbstractArray{Tuple{K,V}}) = $DefaultDict{K,V,F}(default, kv)
         if VERSION >= v"0.4.0-dev+980"
             $DefaultDict{K,V,F}(default::F, ps::Pair{K,V}...) = $DefaultDict{K,V,F}(default, ps...)
         end

--- a/src/hashdict.jl
+++ b/src/hashdict.jl
@@ -13,10 +13,10 @@ else
     const SerState =  Base.Serializer.SerializationState
 end
 
-@compat typealias Unordered Void
+typealias Unordered Void
 typealias Ordered   Int
 
-@compat type HashDict{K,V,O<:Union{Ordered,Unordered}} <: Associative{K,V}
+type HashDict{K,V,O<:Union{Ordered,Unordered}} <: Associative{K,V}
     slots::Array{UInt8,1}
     keys::Array{K,1}
     vals::Array{V,1}
@@ -64,19 +64,19 @@ typealias Ordered   Int
 end
 
 HashDict() = HashDict{Any,Any,Unordered}()
-HashDict(kv::@compat Tuple{}) = HashDict()
+HashDict(kv::Tuple{}) = HashDict()
 HashDict(kv) = hash_dict_with_eltype(kv, eltype(kv))
 
-hash_dict_with_eltype{K,V}(kv, ::Type{@compat Tuple{K,V}}) = HashDict{K,V}(kv)
+hash_dict_with_eltype{K,V}(kv, ::Type{Tuple{K,V}}) = HashDict{K,V}(kv)
 hash_dict_with_eltype(kv, t) = HashDict{Any,Any}(kv)
 
-HashDict{K,V}(kv::AbstractArray{@compat Tuple{K,V}}) = HashDict{K,V,Unordered}(kv)
+HashDict{K,V}(kv::AbstractArray{Tuple{K,V}}) = HashDict{K,V,Unordered}(kv)
 if VERSION >= v"0.4.0-dev+980"
     HashDict{K,V}(ps::Pair{K,V}...) = HashDict{K,V,Unordered}(ps...)
-    HashDict{K,V}(kv::@compat Tuple{Vararg{Pair{K,V}}})         = HashDict{K,V}(kv)
-    HashDict{K}(kv::@compat Tuple{Vararg{Pair{K}}})             = HashDict{K,Any}(kv)
-    HashDict{V}(kv::@compat Tuple{Vararg{Pair{TypeVar(:K),V}}}) = HashDict{Any,V}(kv)
-    HashDict(kv::@compat Tuple{Vararg{Pair}})                   = HashDict{Any,Any}(kv)
+    HashDict{K,V}(kv::Tuple{Vararg{Pair{K,V}}})         = HashDict{K,V}(kv)
+    HashDict{K}(kv::Tuple{Vararg{Pair{K}}})             = HashDict{K,Any}(kv)
+    HashDict{V}(kv::Tuple{Vararg{Pair{TypeVar(:K),V}}}) = HashDict{Any,V}(kv)
+    HashDict(kv::Tuple{Vararg{Pair}})                   = HashDict{Any,Any}(kv)
 
     HashDict{K,V}(kv::AbstractArray{Pair{K,V}}) = HashDict{K,V}(kv)
 
@@ -91,7 +91,7 @@ similar{K,V,O}(d::HashDict{K,V,O}) = HashDict{K,V,O}()
 
 function serialize(s::SerState, t::HashDict)
     serialize_type(s, typeof(t))
-    serialize(s, @compat Int32(length(t)))
+    serialize(s, Int32(length(t)))
     for (k,v) in t
         serialize(s, k)
         serialize(s, v)

--- a/src/multidict.jl
+++ b/src/multidict.jl
@@ -16,11 +16,11 @@ immutable MultiDict{K,V}
 end
 
 MultiDict() = MultiDict{Any,Any}()
-MultiDict(kv::@compat Tuple{}) = MultiDict()
+MultiDict(kv::Tuple{}) = MultiDict()
 MultiDict(kvs) = multi_dict_with_eltype(kvs, eltype(kvs))
 
-multi_dict_with_eltype{K,V}(kvs, ::Type{@compat Tuple{K,Vector{V}}}) = MultiDict{K,V}(kvs)
-function multi_dict_with_eltype{K,V}(kvs, ::Type{@compat Tuple{K,V}})
+multi_dict_with_eltype{K,V}(kvs, ::Type{Tuple{K,Vector{V}}}) = MultiDict{K,V}(kvs)
+function multi_dict_with_eltype{K,V}(kvs, ::Type{Tuple{K,V}})
     md = MultiDict{K,V}()
     for (k,v) in kvs
         insert!(md, k, v)
@@ -68,7 +68,7 @@ function insert!{K,V}(d::MultiDict{K,V}, k, v)
     return d
 end
 
-function in{K,V}(pr::(@compat Tuple{Any,Any}), d::MultiDict{K,V})
+function in{K,V}(pr::(Tuple{Any,Any}), d::MultiDict{K,V})
     k = convert(K, pr[1])
     v = get(d,k,Base.secret_table_token)
     !is(v, Base.secret_table_token) && (isa(pr[2], AbstractArray) ? v == pr[2] : pr[2] in v)

--- a/src/ordereddict.jl
+++ b/src/ordereddict.jl
@@ -5,8 +5,6 @@ import Base: haskey, get, get!, getkey, delete!, push!, pop!, empty!,
              next, done, keys, values, setdiff, setdiff!,
              union, union!, intersect, filter, filter!,
              hash, eltype
-            
-import Compat: keytype, valtype
 
 # This is just a simple wrapper around a HashDict, which is a modified
 # implementation of the Dict implementation in Base allowing ordering
@@ -29,18 +27,18 @@ immutable OrderedDict{K,V} <: Associative{K,V}
 end
 
 OrderedDict() = OrderedDict{Any,Any}()
-OrderedDict(kv::@compat Tuple{}) = OrderedDict()
+OrderedDict(kv::Tuple{}) = OrderedDict()
 OrderedDict(kv) = ordered_dict_with_eltype(kv, eltype(kv))
 
-ordered_dict_with_eltype{K,V}(kv, ::Type{@compat Tuple{K,V}}) = OrderedDict{K,V}(kv)
+ordered_dict_with_eltype{K,V}(kv, ::Type{Tuple{K,V}}) = OrderedDict{K,V}(kv)
 ordered_dict_with_eltype(kv, t) = OrderedDict{Any,Any}(kv)
 
 if VERSION >= v"0.4.0-dev+980"
     OrderedDict{K,V}(ps::Pair{K,V}...)              = OrderedDict{K,V}(ps...)
-    OrderedDict{K,V}(kv::@compat Tuple{Vararg{Pair{K,V}}})         = OrderedDict{K,V}(kv)
-    OrderedDict{K}(kv::@compat Tuple{Vararg{Pair{K}}})             = OrderedDict{K,Any}(kv)
-    OrderedDict{V}(kv::@compat Tuple{Vararg{Pair{TypeVar(:K),V}}}) = OrderedDict{Any,V}(kv)
-    OrderedDict(kv::@compat Tuple{Vararg{Pair}})                   = OrderedDict{Any,Any}(kv)
+    OrderedDict{K,V}(kv::Tuple{Vararg{Pair{K,V}}})         = OrderedDict{K,V}(kv)
+    OrderedDict{K}(kv::Tuple{Vararg{Pair{K}}})             = OrderedDict{K,Any}(kv)
+    OrderedDict{V}(kv::Tuple{Vararg{Pair{TypeVar(:K),V}}}) = OrderedDict{Any,V}(kv)
+    OrderedDict(kv::Tuple{Vararg{Pair}})                   = OrderedDict{Any,Any}(kv)
 
     OrderedDict{K,V}(kv::AbstractArray{Pair{K,V}}) = OrderedDict{K,V}(kv)
 

--- a/src/orderedset.jl
+++ b/src/orderedset.jl
@@ -5,7 +5,7 @@
 # TODO: Most of these functions should be removed once AbstractSet is introduced there
 # (see https://github.com/JuliaLang/julia/issues/5533)
 
-@compat immutable OrderedSet{T}
+immutable OrderedSet{T}
     dict::HashDict{T,Void,Ordered}
 
     OrderedSet() = new(HashDict{T,Void,Ordered}())

--- a/src/sortedDict.jl
+++ b/src/sortedDict.jl
@@ -71,7 +71,7 @@ end
 
 typealias SDSemiToken IntSemiToken
 
-typealias SDToken @compat Tuple{SortedDict,IntSemiToken}
+typealias SDToken Tuple{SortedDict,IntSemiToken}
 
 
 

--- a/src/sortedDict.jl
+++ b/src/sortedDict.jl
@@ -26,70 +26,46 @@ function SortedDict{K, D, Ord <: Ordering}(d::Associative{K,D}, o::Ord=Forward)
 end
 
 
-if VERSION >= v"0.4.0-dev"
 
-    ## More constructors based on those in dict.jl:
-    ## Take pairs and infer argument
-    ## types.  Note:  this works only for the Forward ordering.
+## More constructors based on those in dict.jl:
+## Take pairs and infer argument
+## types.  Note:  this works only for the Forward ordering.
 
-    function SortedDict{K,D}(ps::Pair{K,D}...)
-        h = SortedDict{K,D,ForwardOrdering}()
-        for p in ps
-            h[p.first] = p.second
-        end
-        h 
+function SortedDict{K,D}(ps::Pair{K,D}...)
+    h = SortedDict{K,D,ForwardOrdering}()
+    for p in ps
+        h[p.first] = p.second
     end
-
-
-    ## Take pairs and infer argument
-    ## types.  Ordering parameter must be explicit first argument.
-
-
-    function SortedDict{K,D, Ord <: Ordering}(o::Ord, ps::Pair{K,D}...)
-        h = SortedDict{K,D,Ord}(o)
-        for p in ps
-            h[p.first] = p.second
-        end
-        h 
-    end
-
-    ## This one takes an iterable; ordering type is optional.
-
-    SortedDict{Ord <: Ordering}(kv, o::Ord=Forward) = 
-    sorteddict_with_eltype(kv, eltype(kv), o)
-
-    function sorteddict_with_eltype{K,D,Ord}(kv, ::Type{Pair{K,D}}, o::Ord)
-        h = SortedDict{K,D,Ord}(o)
-        for (k,v) in kv
-            h[k] = v
-        end
-        h
-    end
-
-else   #if VERSION < v"0.4.0-dev"
-    function SortedDict{K,D,Ord <: Ordering}(ks::AbstractArray{K},
-                                             vs::AbstractArray{D},
-                                             o::Ord = Forward) 
-        h = SortedDict{K,D,Ord}(o)
-        l = length(ks)
-        if length(vs) != l
-            error("ks and vs arrays in two-array SortedDict constructor must have the same length")
-        end
-        for i = 1 : l
-            h[ks[i]] = vs[i]
-        end
-        h
-    end
-
-    function SortedDict{K,D,Ord <: Ordering}(kv::AbstractArray{(K,D),1},
-                                             o::Ord = Forward)
-        h = SortedDict{K,D,Ord}(o)
-        for pr in kv
-            h[pr[1]] = pr[2]
-        end
-        h
-    end
+    h 
 end
+
+
+## Take pairs and infer argument
+## types.  Ordering parameter must be explicit first argument.
+
+
+function SortedDict{K,D, Ord <: Ordering}(o::Ord, ps::Pair{K,D}...)
+    h = SortedDict{K,D,Ord}(o)
+    for p in ps
+        h[p.first] = p.second
+    end
+    h 
+end
+
+## This one takes an iterable; ordering type is optional.
+
+SortedDict{Ord <: Ordering}(kv, o::Ord=Forward) = 
+sorteddict_with_eltype(kv, eltype(kv), o)
+
+function sorteddict_with_eltype{K,D,Ord}(kv, ::Type{Pair{K,D}}, o::Ord)
+    h = SortedDict{K,D,Ord}(o)
+    for (k,v) in kv
+        h[k] = v
+    end
+    h
+end
+
+
 
 
 
@@ -120,20 +96,10 @@ end
 
 ## push! is an alternative to insert!; it returns the container.
 
-if VERSION >= v"0.4.0-dev"
 
 @inline function push!{K, D, Ord <: Ordering}(m::SortedDict{K,D,Ord}, pr::Pair{K,D})
     insert!(m.bt, convert(K,pr[1]), convert(D,pr[2]), false)
     m
-end
-
-else
-
-@inline function push!{K, D, Ord <: Ordering}(m::SortedDict{K,D,Ord}, k_, d_)
-    insert!(m.bt, convert(K,k_), convert(D,d_), false)
-    m
-end
-
 end
 
 
@@ -163,7 +129,6 @@ end
 end
 
 
-if VERSION >= v"0.4.0-dev"
 
 @inline eltype{K,D,Ord <: Ordering}(m::SortedDict{K,D,Ord}) =  Pair{K,D}
 @inline eltype{K,D,Ord <: Ordering}(::Type{SortedDict{K,D,Ord}}) =  Pair{K,D}
@@ -175,18 +140,6 @@ end
 @inline in(::Tuple{Any,Any}, ::SortedDict) =
     throw(ArgumentError("'(k,v) in sorteddict' not supported in Julia 0.4 or 0.5.  See documentation"))
 
-
-else
-
-@inline function in{K,D,Ord <: Ordering}(pr::(Any,Any), m::SortedDict{K,D,Ord})
-    i, exactfound = findkey(m.bt,convert(K,pr[1]))
-    return exactfound && isequal(m.bt.data[i].d,convert(D,pr[2]))
-end
-
-@inline eltype{K,D,Ord <: Ordering}(m::SortedDict{K,D,Ord}) =  (K,D)
-@inline eltype{K,D,Ord <: Ordering}(::Type{SortedDict{K,D,Ord}}) =  (K,D)
-
-end
 
 @inline keytype{K,D,Ord <: Ordering}(m::SortedDict{K,D,Ord}) = K
 @inline keytype{K,D,Ord <: Ordering}(::Type{SortedDict{K,D,Ord}}) = K

--- a/src/sortedMultiDict.jl
+++ b/src/sortedMultiDict.jl
@@ -35,62 +35,44 @@ function SortedMultiDict{K,D, Ord <: Ordering}(kk::AbstractArray{K,1},
 end
 
 
-if VERSION >= v"0.4.0-dev"
 
-    ## Take pairs and infer argument
-    ## types.  Note:  this works only for the Forward ordering.
+## Take pairs and infer argument
+## types.  Note:  this works only for the Forward ordering.
 
-    function SortedMultiDict{K,D}(ps::Pair{K,D}...)
-        h = SortedMultiDict{K,D,ForwardOrdering}()
-        for p in ps
-            insert!(h, p.first, p.second)
-        end
-        h 
+function SortedMultiDict{K,D}(ps::Pair{K,D}...)
+    h = SortedMultiDict{K,D,ForwardOrdering}()
+    for p in ps
+        insert!(h, p.first, p.second)
     end
-
-
-    ## Take pairs and infer argument
-    ## types.  Ordering parameter must be explicit first argument.
-
-
-    function SortedMultiDict{K,D, Ord <: Ordering}(o::Ord, ps::Pair{K,D}...)
-        h = SortedMultiDict{K,D,Ord}(o)
-        for p in ps
-            insert!(h, p.first, p.second)
-        end
-        h 
-    end
-
-
-    ## This one takes an iterable; ordering type is optional.
-
-    SortedMultiDict{Ord <: Ordering}(kv, o::Ord=Forward) = 
-    sortedmultidict_with_eltype(kv, eltype(kv), o)
-
-    function sortedmultidict_with_eltype{K,D,Ord}(kv, ::Type{Pair{K,D}}, o::Ord)
-        h = SortedMultiDict{K,D,Ord}(o)
-        for (k,v) in kv
-            insert!(h, k, v)
-        end
-        h
-    end
-
-
-else # if VERSION < v"0.4.0-dev"
-
-    function SortedMultiDict{K,D,Ord <: Ordering}(kv::AbstractArray{(K,D),1},
-                                                  o::Ord = Forward)
-        h = SortedMultiDict{K,D,Ord}(o)
-        for pr in kv
-            insert!(h, pr[1], pr[2])
-        end
-        h
-    end
+    h 
 end
 
 
+## Take pairs and infer argument
+## types.  Ordering parameter must be explicit first argument.
 
 
+function SortedMultiDict{K,D, Ord <: Ordering}(o::Ord, ps::Pair{K,D}...)
+    h = SortedMultiDict{K,D,Ord}(o)
+    for p in ps
+        insert!(h, p.first, p.second)
+    end
+    h 
+end
+
+
+## This one takes an iterable; ordering type is optional.
+
+SortedMultiDict{Ord <: Ordering}(kv, o::Ord=Forward) = 
+sortedmultidict_with_eltype(kv, eltype(kv), o)
+
+function sortedmultidict_with_eltype{K,D,Ord}(kv, ::Type{Pair{K,D}}, o::Ord)
+    h = SortedMultiDict{K,D,Ord}(o)
+    for (k,v) in kv
+        insert!(h, k, v)
+    end
+    h
+end
 
 
 ## This function inserts an item into the tree.
@@ -104,23 +86,11 @@ end
 
 ## push! is an alternative to insert!; it returns the container.
 
-if VERSION >= v"0.4.0-dev"
 
 @inline function push!{K, D, Ord <: Ordering}(m::SortedMultiDict{K,D,Ord}, pr::Pair{K,D})
     insert!(m.bt, convert(K,pr[1]), convert(D,pr[2]), true)
     m
 end
-
-else
-
-@inline function push!{K, D, Ord <: Ordering}(m::SortedMultiDict{K,D,Ord}, k_, d_)
-    insert!(m.bt, convert(K,k_), convert(D,d_), true)
-    m
-end
-
-end
-
-
 
 
 
@@ -179,8 +149,6 @@ end
 
  
 
-if VERSION >= v"0.4.0-dev"
-
 @inline eltype{K,D,Ord <: Ordering}(m::SortedMultiDict{K,D,Ord}) =  Pair{K,D}
 @inline eltype{K,D,Ord <: Ordering}(::Type{SortedMultiDict{K,D,Ord}}) =  Pair{K,D}
 @inline in(pr::Pair, m::SortedMultiDict) =
@@ -189,16 +157,6 @@ if VERSION >= v"0.4.0-dev"
     throw(ArgumentError("'(k,v) in sortedmultidict' not supported in Julia 0.4 or 0.5.  See documentation"))
 
 
-
-else
-
-
-@inline eltype{K,D,Ord <: Ordering}(m::SortedMultiDict{K,D,Ord}) =  (K,D)
-@inline eltype{K,D,Ord <: Ordering}(::Type{SortedMultiDict{K,D,Ord}}) =  (K,D)
-@inline in{K,D,Ord <: Ordering}(pr::(Any,Any), m::SortedMultiDict{K,D,Ord}) =
-    in_(pr[1], pr[2], m)
-
-end
 
 @inline keytype{K,D,Ord <: Ordering}(m::SortedMultiDict{K,D,Ord}) = K
 @inline keytype{K,D,Ord <: Ordering}(::Type{SortedMultiDict{K,D,Ord}}) = K

--- a/src/sortedMultiDict.jl
+++ b/src/sortedMultiDict.jl
@@ -16,7 +16,7 @@ end
 
 typealias SMDSemiToken IntSemiToken
 
-typealias SMDToken @compat Tuple{SortedMultiDict, IntSemiToken}
+typealias SMDToken Tuple{SortedMultiDict, IntSemiToken}
 
 ## This constructor takes two arrays an ordering object which defaults
 ## to Forward
@@ -44,7 +44,7 @@ function SortedMultiDict{K,D}(ps::Pair{K,D}...)
     for p in ps
         insert!(h, p.first, p.second)
     end
-    h 
+    h
 end
 
 
@@ -57,13 +57,13 @@ function SortedMultiDict{K,D, Ord <: Ordering}(o::Ord, ps::Pair{K,D}...)
     for p in ps
         insert!(h, p.first, p.second)
     end
-    h 
+    h
 end
 
 
 ## This one takes an iterable; ordering type is optional.
 
-SortedMultiDict{Ord <: Ordering}(kv, o::Ord=Forward) = 
+SortedMultiDict{Ord <: Ordering}(kv, o::Ord=Forward) =
 sortedmultidict_with_eltype(kv, eltype(kv), o)
 
 function sortedmultidict_with_eltype{K,D,Ord}(kv, ::Type{Pair{K,D}}, o::Ord)
@@ -126,9 +126,9 @@ end
 
 
 
-## '(k,d) in m' checks whether a key-data pair is in 
+## '(k,d) in m' checks whether a key-data pair is in
 ## a sorted multidict.  This requires a loop over
-## all data items whose key is equal to k. 
+## all data items whose key is equal to k.
 
 
 function in_(k_, d_, m::SortedMultiDict)
@@ -147,13 +147,13 @@ function in_(k_, d_, m::SortedMultiDict)
 end
 
 
- 
+
 
 @inline eltype{K,D,Ord <: Ordering}(m::SortedMultiDict{K,D,Ord}) =  Pair{K,D}
 @inline eltype{K,D,Ord <: Ordering}(::Type{SortedMultiDict{K,D,Ord}}) =  Pair{K,D}
 @inline in(pr::Pair, m::SortedMultiDict) =
     in_(pr[1], pr[2], m)
-@inline in(::Tuple{Any,Any}, ::SortedMultiDict) = 
+@inline in(::Tuple{Any,Any}, ::SortedMultiDict) =
     throw(ArgumentError("'(k,v) in sortedmultidict' not supported in Julia 0.4 or 0.5.  See documentation"))
 
 
@@ -199,7 +199,7 @@ function isequal(m1::SortedMultiDict, m2::SortedMultiDict)
     end
 end
 
-@compat typealias SDorAssociative Union{Associative,SortedMultiDict}
+typealias SDorAssociative Union{Associative,SortedMultiDict}
 
 function mergetwo!{K,D,Ord <: Ordering}(m::SortedMultiDict{K,D,Ord},
                                         m2::SDorAssociative)
@@ -223,14 +223,14 @@ function packdeepcopy{K,D,Ord <: Ordering}(m::SortedMultiDict{K,D,Ord})
 end
 
 
-function merge!{K,D,Ord <: Ordering}(m::SortedMultiDict{K,D,Ord}, 
+function merge!{K,D,Ord <: Ordering}(m::SortedMultiDict{K,D,Ord},
                                      others::SDorAssociative...)
     for o in others
         mergetwo!(m,o)
     end
 end
 
-function merge{K,D,Ord <: Ordering}(m::SortedMultiDict{K,D,Ord}, 
+function merge{K,D,Ord <: Ordering}(m::SortedMultiDict{K,D,Ord},
                                     others::SDorAssociative...)
     result = packcopy(m)
     merge!(result, others...)
@@ -250,5 +250,5 @@ function Base.show{K,D,Ord <: Ordering}(io::IO, m::SortedMultiDict{K,D,Ord})
     print(io, ")")
 end
 
-similar{K,D,Ord<:Ordering}(m::SortedMultiDict{K,D,Ord}) = 
+similar{K,D,Ord<:Ordering}(m::SortedMultiDict{K,D,Ord}) =
    SortedMultiDict(K[], D[], orderobject(m))

--- a/src/sortedSet.jl
+++ b/src/sortedSet.jl
@@ -2,7 +2,7 @@
 ## methods similiar to those of the julia Set.
 
 
-@compat type SortedSet{K, Ord <: Ordering}
+type SortedSet{K, Ord <: Ordering}
     bt::BalancedTree23{K,Void,Ord}
 
     ## Zero-argument constructor, or possibly one argument to specify order.

--- a/src/tokens2.jl
+++ b/src/tokens2.jl
@@ -3,12 +3,12 @@ import Base.isequal
 import Base.colon
 import Base.endof
 
-@compat typealias SDMContainer Union{SortedDict, SortedMultiDict}
-@compat typealias SAContainer Union{SDMContainer, SortedSet}
+typealias SDMContainer Union{SortedDict, SortedMultiDict}
+typealias SAContainer Union{SDMContainer, SortedSet}
 
-typealias Token @compat Tuple{SAContainer, IntSemiToken}
-typealias SDMToken @compat Tuple{SDMContainer, IntSemiToken}
-typealias SetToken @compat Tuple{SortedSet, IntSemiToken}
+typealias Token Tuple{SAContainer, IntSemiToken}
+typealias SDMToken Tuple{SDMContainer, IntSemiToken}
+typealias SetToken Tuple{SortedSet, IntSemiToken}
 
 
 if VERSION >= v"0.4.0-dev"

--- a/src/trie.jl
+++ b/src/trie.jl
@@ -29,9 +29,9 @@ end
 
 Trie() = Trie{Any}()
 Trie{K<:AbstractString,V}(ks::AbstractVector{K}, vs::AbstractVector{V}) = Trie{V}(ks, vs)
-Trie{K<:AbstractString,V}(kv::AbstractVector{@compat Tuple{K,V}}) = Trie{V}(kv)
+Trie{K<:AbstractString,V}(kv::AbstractVector{Tuple{K,V}}) = Trie{V}(kv)
 Trie{K<:AbstractString,V}(kv::Associative{K,V}) = Trie{V}(kv)
-@compat Trie{K<:AbstractString}(ks::AbstractVector{K}) = Trie{Void}(ks, similar(ks, Void))
+Trie{K<:AbstractString}(ks::AbstractVector{K}) = Trie{Void}(ks, similar(ks, Void))
 
 function setindex!{T}(t::Trie{T}, val::T, key::AbstractString)
     node = t

--- a/test/test_deque.jl
+++ b/test/test_deque.jl
@@ -1,6 +1,5 @@
 using DataStructures
 using Base.Test
-using Compat
 
 
 # empty dequeue
@@ -43,7 +42,7 @@ for i = 1 : n
 
     @test front(q) == 1
     @test back(q) == i
-    
+
     k = 1
     for j in q
         @test j == k

--- a/test/test_ordereddict.jl
+++ b/test/test_ordereddict.jl
@@ -144,7 +144,7 @@ let
     d = OrderedDict([(1, 2), (3, 4)])
     @test d[1] === 2
     @test d[3] === 4
-    ## TODO: @compat only rewrites Dict, not OrderedDict
+    ## TODO: test this
     # d2 = OrderedDict(1 => 2, 3 => 4)
     # d3 = OrderedDict((1 => 2, 3 => 4))
     # @test d == d2 == d3
@@ -294,8 +294,8 @@ end
 
 # Test merging
 let
-    a = @compat OrderedDict("foo"  => 0.0, "bar" => 42.0)
-    b = @compat OrderedDict("フー" => 17, "バー" => 4711)
+    a = OrderedDict("foo"  => 0.0, "bar" => 42.0)
+    b = OrderedDict("フー" => 17, "バー" => 4711)
     @test is(typeof(merge(a, b)), OrderedDict{UTF8String,Float64})
 end
 

--- a/test/test_sortedcontainers.jl
+++ b/test/test_sortedcontainers.jl
@@ -76,21 +76,10 @@ function fulldump(t::DataStructures.BalancedTree23)
 end
 
 
-if VERSION >= v"0.4.0-dev"
 
 tuple_or_pair(K::DataType, V::DataType) = Pair{K,V}
 tuple_or_pair(k,v) = k=>v
 push_test!(m, k, v) = push!(m, k=>v)
-
-else
-
-tuple_or_pair(K::DataType, V::DataType) = (K,V)
-tuple_or_pair(k,v) = (k,v)
-push_test!(m, k, v) = push!(m, k, v)
-
-
-end
-
 
 
 
@@ -472,16 +461,14 @@ function test2()
     @test tpr == tuple_or_pair(Int,Float64)
     tpr2 = eltype(typeof(m1))
     @test tpr2 == tuple_or_pair(Int,Float64)
-    if VERSION >= v"0.4.0-dev"
-        kt = keytype(m1)
-        @test kt == Int
-        kt2 = keytype(typeof(m1))
-        @test kt2 == Int
-        vt = valtype(m1)
-        @test vt == Float64
-        vt2 = valtype(typeof(m1))
-        @test vt2 == Float64
-    end
+    kt = keytype(m1)
+    @test kt == Int
+    kt2 = keytype(typeof(m1))
+    @test kt2 == Int
+    vt = valtype(m1)
+    @test vt == Float64
+    vt2 = valtype(typeof(m1))
+    @test vt2 == Float64
     
 
     co = orderobject(m1)
@@ -612,16 +599,14 @@ function test3{T}(z::T)
     
     sk2a = zero1
 
-    if VERSION >= v"0.4.0-dev"
 
-        for k in eachindex(m1)
-            sk2a += k
-        end
-        @test eltype(eachindex(m1)) == T
-        @test sk2a == sk
-
+    for k in eachindex(m1)
+        sk2a += k
     end
+    @test eltype(eachindex(m1)) == T
+    @test sk2a == sk
 
+    
 
     sk2b = zero1
     for st in onlysemitokens(m1)
@@ -661,14 +646,13 @@ function test3{T}(z::T)
     @test eltype(keys(exclusive(m1, startof(m1), pos1))) == T
 
 
-    if VERSION >= v"0.4.0-dev"
-        sk2a = zero1
-        for k in eachindex(exclusive(m1, startof(m1), pos1))
-            sk2a += k
-        end
-        @test sk2a == skhalf
-        @test eltype(eachindex(exclusive(m1, startof(m1), pos1))) == T
+
+    sk2a = zero1
+    for k in eachindex(exclusive(m1, startof(m1), pos1))
+        sk2a += k
     end
+    @test sk2a == skhalf
+    @test eltype(eachindex(exclusive(m1, startof(m1), pos1))) == T
 
 
 
@@ -694,16 +678,14 @@ function test3{T}(z::T)
        T
 
 
-    if VERSION >= v"0.4.0-dev"
-        count = 0
-        sk5 = zero1
-        for k in eachindex(inclusive(m1, startof(m1), startof(m1)))
-            sk5 += k
-            count += 1
-        end
-        @test count == 1 && sk5 == deref_key((m1,startof(m1)))
-        @test eltype(eachindex(inclusive(m1, startof(m1), startof(m1)))) == T
+    count = 0
+    sk5 = zero1
+    for k in eachindex(inclusive(m1, startof(m1), startof(m1)))
+        sk5 += k
+        count += 1
     end
+    @test count == 1 && sk5 == deref_key((m1,startof(m1)))
+    @test eltype(eachindex(inclusive(m1, startof(m1), startof(m1)))) == T
 
     factors = SortedMultiDict(Int[], Int[])
     N = 1000
@@ -732,16 +714,14 @@ function test3{T}(z::T)
 
 
 
-    if VERSION >= v"0.4.0-dev"
-        sum1a = 0
-        sum2a = 0
-        for st in eachindex(factors)
-            (k,v) = deref((factors,st))
-            sum1a += k
-            sum2a += v
-        end
-        @test sum1a == sum1 && sum2a == sum2
+    sum1a = 0
+    sum2a = 0
+    for st in eachindex(factors)
+        (k,v) = deref((factors,st))
+        sum1a += k
+        sum2a += v
     end
+    @test sum1a == sum1 && sum2a == sum2
 
     sum1a = 0
     sum2a = 0
@@ -765,24 +745,22 @@ function test3{T}(z::T)
                            searchsortedfirst(factors,70),
                            searchsortedlast(factors,70))) == tuple_or_pair(Int,Int)
 
-    if VERSION >= v"0.4.0-dev"
 
-        sum2 = 0
-        for st in eachindex(inclusive(factors, 
-                                      searchsortedfirst(factors,70),
-                                      searchsortedlast(factors,70)))
-            v = deref_value((factors,st))
-            sum2 += v
-        end
-
-        @test sum2 == 1 + 2 + 5 + 7 + 10 + 14 + 35 + 70
-        @test eltype(eachindex(inclusive(factors, 
-                                         searchsortedfirst(factors,70),
-                                         searchsortedlast(factors,70)))) == IntSemiToken
+    sum2 = 0
+    for st in eachindex(inclusive(factors, 
+                                  searchsortedfirst(factors,70),
+                                  searchsortedlast(factors,70)))
+        v = deref_value((factors,st))
+        sum2 += v
     end
-
-
     
+    @test sum2 == 1 + 2 + 5 + 7 + 10 + 14 + 35 + 70
+    @test eltype(eachindex(inclusive(factors, 
+                                     searchsortedfirst(factors,70),
+                                     searchsortedlast(factors,70)))) == IntSemiToken
+
+
+
     sum3 = 0
     for (k,v) in exclusive(factors,
                            searchsortedfirst(factors,60), 
@@ -795,19 +773,17 @@ function test3{T}(z::T)
                            searchsortedlast(factors,70))) == tuple_or_pair(Int,Int)
 
 
-    if VERSION >= v"0.4.0-dev"
-        sum3 = 0
-        for st in eachindex(exclusive(factors,
-                                      searchsortedfirst(factors,60), 
-                                      searchsortedfirst(factors,61)))
-            v = deref_value((factors,st))
-            sum3 += v
-        end
-        @test sum3 == 1 + 2 + 3 + 4 + 5 + 6 + 10 + 12 + 15 + 20 + 30 + 60
-        @test eltype(eachindex(exclusive(factors, 
-                                         searchsortedfirst(factors,70),
-                                         searchsortedlast(factors,70)))) == IntSemiToken
+    sum3 = 0
+    for st in eachindex(exclusive(factors,
+                                  searchsortedfirst(factors,60), 
+                                  searchsortedfirst(factors,61)))
+        v = deref_value((factors,st))
+        sum3 += v
     end
+    @test sum3 == 1 + 2 + 3 + 4 + 5 + 6 + 10 + 12 + 15 + 20 + 30 + 60
+    @test eltype(eachindex(exclusive(factors, 
+                                     searchsortedfirst(factors,70),
+                                     searchsortedlast(factors,70)))) == IntSemiToken
 
 
     sum4 = 0
@@ -1003,16 +979,14 @@ function test3{T}(z::T)
     @test sum1 == sum([39, 24, 2, 14, 45, 107, 66])
     @test eltype(onlysemitokens(s)) == IntSemiToken
 
-    if VERSION >= v"0.4.0-dev"
 
-        sum1 = 0
-        for st in eachindex(s)
-            k = deref((s,st))
-            sum1 += k
-        end
-        @test sum1 == sum([39, 24, 2, 14, 45, 107, 66])
-        @test eltype(eachindex(s)) == IntSemiToken
+    sum1 = 0
+    for st in eachindex(s)
+        k = deref((s,st))
+        sum1 += k
     end
+    @test sum1 == sum([39, 24, 2, 14, 45, 107, 66])
+    @test eltype(eachindex(s)) == IntSemiToken
 
 
     sum2 = 0
@@ -1027,18 +1001,16 @@ function test3{T}(z::T)
                        searchsortedfirst(s, 66))) == Int
 
 
-    if VERSION >= v"0.4.0-dev"
-        sum2 = 0
-        for st in eachindex(inclusive(s,
-                                      searchsortedfirst(s, 24), 
-                                      searchsortedfirst(s, 66)))
-            sum2 += deref((s,st))
-        end
-        @test sum2 == 24 + 39 + 45 + 66
-        @test eltype(eachindex(inclusive(s,
-                                         searchsortedfirst(s, 24), 
-                                         searchsortedfirst(s, 66)))) == IntSemiToken
+    sum2 = 0
+    for st in eachindex(inclusive(s,
+                                  searchsortedfirst(s, 24), 
+                                  searchsortedfirst(s, 66)))
+        sum2 += deref((s,st))
     end
+    @test sum2 == 24 + 39 + 45 + 66
+    @test eltype(eachindex(inclusive(s,
+                                     searchsortedfirst(s, 24), 
+                                     searchsortedfirst(s, 66)))) == IntSemiToken
 
 
 
@@ -1096,19 +1068,17 @@ function test3{T}(z::T)
                                        searchsortedfirst(s, 66)))) ==
      @compat Tuple{IntSemiToken, Int}
 
-    if VERSION >= v"0.4.0-dev"
 
-        sum3 = 0
-        for st in eachindex(exclusive(s,
-                                      searchsortedfirst(s, 24), 
-                                      searchsortedfirst(s, 66)))
-            sum3 += deref((s,st))
-        end
-        @test sum3 == 24 + 39 + 45
-        @test eltype(eachindex(exclusive(s,
-                                         searchsortedfirst(s, 24), 
-                                         searchsortedfirst(s, 66)))) == IntSemiToken
+    sum3 = 0
+    for st in eachindex(exclusive(s,
+                                  searchsortedfirst(s, 24), 
+                                  searchsortedfirst(s, 66)))
+        sum3 += deref((s,st))
     end
+    @test sum3 == 24 + 39 + 45
+    @test eltype(eachindex(exclusive(s,
+                                     searchsortedfirst(s, 24), 
+                                     searchsortedfirst(s, 66)))) == IntSemiToken
     nothing
 end
 
@@ -1152,10 +1122,8 @@ function test4()
     @test_throws BoundsError last(s)
     @test_throws ArgumentError isequal(SortedSet(["a"]), SortedSet([1]))
     @test_throws ArgumentError isequal(SortedSet(["a"]), SortedSet(["b"],Reverse))
-    if VERSION >= v"0.4.0-dev"
-        @test_throws ArgumentError (("a",6) in m)
-        @test_throws ArgumentError ((2,5) in m1)
-    end
+    @test_throws ArgumentError (("a",6) in m)
+    @test_throws ArgumentError ((2,5) in m1)
     nothing
 end
 
@@ -1382,12 +1350,10 @@ function test7()
     @test eltype(factors) == tuple_or_pair(Int,Int)
     @test eltype(typeof(factors)) == tuple_or_pair(Int,Int)
 
-    if VERSION >= v"0.4.0-dev"
-        @test keytype(factors) == Int
-        @test keytype(typeof(factors)) == Int
-        @test valtype(factors) == Int
-        @test valtype(typeof(factors)) == Int
-    end
+    @test keytype(factors) == Int
+    @test keytype(typeof(factors)) == Int
+    @test valtype(factors) == Int
+    @test valtype(typeof(factors)) == Int
 
     push_test!(factors, 70,3)
     @test length(factors) == len+1
@@ -1635,10 +1601,8 @@ function test8()
     @test !haskey(m,0.5)
     @test eltype(m) == Float64
     @test eltype(typeof(m)) == Float64
-    if VERSION >= v"0.4.0-dev"
-        @test keytype(m) == Float64
-        @test keytype(typeof(m)) == Float64
-    end
+    @test keytype(m) == Float64
+    @test keytype(typeof(m)) == Float64
     @test orderobject(m) == Forward
     pop!(m, smallest)
     checkcorrectness(m.bt, false)
@@ -1704,60 +1668,35 @@ end
                
 
 # test the constructors of SortedDict and SortedMultiDict
-if VERSION >= v"0.4.0-dev"
 
-    function test9()
+function test9()
 
-        sd1 = SortedDict("w" => 64, "p" => 12)
-        @test length(sd1) == 2 && first(sd1) == ("p"=>12) &&
-            last(sd1) == ("w"=>64)
-        sd2 = SortedDict(Reverse, "w" => 64, "p" => 12)
-        @test length(sd2) == 2 && last(sd2) == ("p"=>12) &&
-            first(sd2) == ("w"=>64)
-        sd3 = SortedDict(("w"=>64, "p"=>12))
-        @test length(sd3) == 2 && first(sd3) == ("p"=>12) &&
-            last(sd3) == ("w"=>64)
-        sd4 = SortedDict(("w"=>64, "p"=>12), Reverse)
-        @test length(sd4) == 2 && last(sd4) == ("p"=>12) &&
-            first(sd4) == ("w"=>64)
-        sm1 = SortedMultiDict("w" => 64, "p" => 12, "p" => 9)
-        @test length(sm1) == 3 && first(sm1) == ("p"=>12) &&
-            last(sm1) == ("w"=>64)
-        sm2 = SortedMultiDict(Reverse, "w" => 64, "p" => 12, "p" => 9)
-        @test length(sm2) == 3 && last(sm2) == ("p"=>9) &&
-            first(sm2) == ("w"=>64)
-        sm3 = SortedMultiDict(("w"=>64, "p"=>12, "p"=> 9))
-        @test length(sm3) == 3 && first(sm3) == ("p"=>12) &&
-            last(sm3) == ("w"=>64)
-        sm4 = SortedMultiDict(("w"=> 64, "p"=>12, "p"=>9), Reverse)
-        @test length(sm4) == 3 && last(sm4) == ("p"=>9) &&
-            first(sm4) == ("w"=>64)
-        nothing
-    end
-else
-    function test9()
-        sd1 = SortedDict(["w", "p"], [64,12])
-        @test length(sd1) == 2 && first(sd1) == ("p",12) &&
-            last(sd1) == ("w",64)
-        sd2 = SortedDict(["w", "p"], [64,12], Reverse)
-        @test length(sd2) == 2 && last(sd2) == ("p",12) &&
-            first(sd2) == ("w",64)
-        sd3 = SortedDict([("w",64), ("p",12)])
-        @test length(sd3) == 2 && first(sd3) == ("p",12) &&
-            last(sd3) == ("w",64)
-        sd4 = SortedDict([("w", 64), ("p",12)], Reverse)
-        @test length(sd4) == 2 && last(sd4) == ("p",12) &&
-            first(sd4) == ("w",64)
-        sm3 = SortedMultiDict([("w",64), ("p",12), ("p", 9)])
-        @test length(sm3) == 3 && first(sm3) == ("p",12) &&
-            last(sm3) == ("w",64)
-        sm4 = SortedMultiDict([("w", 64), ("p",12), ("p", 9)], Reverse)
-        @test length(sm4) == 3 && last(sm4) == ("p",9) &&
-            first(sm4) == ("w",64)
-        nothing
-    end
+    sd1 = SortedDict("w" => 64, "p" => 12)
+    @test length(sd1) == 2 && first(sd1) == ("p"=>12) &&
+        last(sd1) == ("w"=>64)
+    sd2 = SortedDict(Reverse, "w" => 64, "p" => 12)
+    @test length(sd2) == 2 && last(sd2) == ("p"=>12) &&
+        first(sd2) == ("w"=>64)
+    sd3 = SortedDict(("w"=>64, "p"=>12))
+    @test length(sd3) == 2 && first(sd3) == ("p"=>12) &&
+        last(sd3) == ("w"=>64)
+    sd4 = SortedDict(("w"=>64, "p"=>12), Reverse)
+    @test length(sd4) == 2 && last(sd4) == ("p"=>12) &&
+        first(sd4) == ("w"=>64)
+    sm1 = SortedMultiDict("w" => 64, "p" => 12, "p" => 9)
+    @test length(sm1) == 3 && first(sm1) == ("p"=>12) &&
+        last(sm1) == ("w"=>64)
+    sm2 = SortedMultiDict(Reverse, "w" => 64, "p" => 12, "p" => 9)
+    @test length(sm2) == 3 && last(sm2) == ("p"=>9) &&
+        first(sm2) == ("w"=>64)
+    sm3 = SortedMultiDict(("w"=>64, "p"=>12, "p"=> 9))
+    @test length(sm3) == 3 && first(sm3) == ("p"=>12) &&
+        last(sm3) == ("w"=>64)
+    sm4 = SortedMultiDict(("w"=> 64, "p"=>12, "p"=>9), Reverse)
+    @test length(sm4) == 3 && last(sm4) == ("p"=>9) &&
+        first(sm4) == ("w"=>64)
+    nothing
 end
-
 
 
 test1()

--- a/test/test_sortedcontainers.jl
+++ b/test/test_sortedcontainers.jl
@@ -1,5 +1,4 @@
 using DataStructures
-using Compat
 import Base.Ordering
 import Base.Forward
 import Base.Reverse
@@ -148,10 +147,10 @@ function checkcorrectness{K,D,Ord <: Ordering}(t::DataStructures.BalancedTree23{
         else
             maxkeys[s] = t.data[lastchild].k
         end
-        if s > levstart[tdpth] && 
+        if s > levstart[tdpth] &&
             (lt(t.ord, minkeys[s], maxkeys[s - 1]) ||
              (!lt(t.ord, maxkeys[s-1],minkeys[s]) && !allowdups))
-            println("tdpth = ", tdpth, " s = ", s, 
+            println("tdpth = ", tdpth, " s = ", s,
                     " maxkeys[s-1] = ", maxkeys[s-1],
                     " minkeys[s] = ", minkeys[s])
             error("Data nodes out of order")
@@ -202,9 +201,9 @@ function checkcorrectness{K,D,Ord <: Ordering}(t::DataStructures.BalancedTree23{
                 error("Parent/child2 links do not match")
             end
             c3 = t.tree[anc].child3
-            @assert(s == levstart[curdepth] || 
+            @assert(s == levstart[curdepth] ||
                     lt(t.ord,mk1,mk2) || (!lt(t.ord,mk2,mk1) && allowdups))
-            if c3 > 0 
+            if c3 > 0
                 if t.tree[c3].parent != anc
                     error("Parent/child3 links do not match")
                 end
@@ -271,7 +270,7 @@ end
 
 function test1()
     # a few basic tests of SortedDict to start
-    m1 = SortedDict((@compat Dict{ASCIIString,ASCIIString}()), Forward)
+    m1 = SortedDict((Dict{ASCIIString,ASCIIString}()), Forward)
     kdarray = ["hello", "jello", "alpha", "beta", "fortune", "random",
                "july", "wednesday"]
     checkcorrectness(m1.bt, false)
@@ -298,8 +297,8 @@ end
 
 function test2()
     # test all methods of SortedDict here except loops
-    m0 = SortedDict(@compat Dict{Int, Float64}())
-    m1 = SortedDict(@compat Dict(8=>32.0, 12=>33.1, 6=>18.2))
+    m0 = SortedDict(Dict{Int, Float64}())
+    m1 = SortedDict(Dict(8=>32.0, 12=>33.1, 6=>18.2))
     expected = ([6,8,12], [18.2, 32.0, 33.1])
     checkcorrectness(m1.bt, false)
     ii = startof(m1)
@@ -406,7 +405,7 @@ function test2()
     @test t == sum(pn)
     @test u == sum(pn.^2)
     ij = endof(m1)
-    @test deref_key((m1,ij)) == last(pn) && 
+    @test deref_key((m1,ij)) == last(pn) &&
        convert(Float64, last(pn)^2) ==  deref_value((m1,ij))
     m1[6] = 49.0
     @test length(m1) == numprimes + 1
@@ -469,7 +468,7 @@ function test2()
     @test vt == Float64
     vt2 = valtype(typeof(m1))
     @test vt2 == Float64
-    
+
 
     co = orderobject(m1)
     @test co == Forward
@@ -493,22 +492,22 @@ function test2()
     empty!(m1)
     checkcorrectness(m1.bt, false)
     @test isempty(m1)
-    c1 = SortedDict(@compat Dict("Eggplants"=>3, 
-                        "Figs"=>9, 
+    c1 = SortedDict(Dict("Eggplants"=>3,
+                        "Figs"=>9,
                         "Apples"=>7))
-    c2 = SortedDict(@compat Dict("Eggplants"=>6, 
-                        "Honeydews"=>19, 
+    c2 = SortedDict(Dict("Eggplants"=>6,
+                        "Honeydews"=>19,
                         "Melons"=>11))
     @test !isequal(c1,c2)
     c3 = merge(c1, c2)
     checkcorrectness(c3.bt, false)
-    c4 = SortedDict(@compat Dict("Apples"=>7, 
+    c4 = SortedDict(Dict("Apples"=>7,
                         "Figs"=>9,
                         "Eggplants"=>6,
                         "Melons"=>11,
                         "Honeydews"=>19))
     @test isequal(c3,c4)
-    c5 = SortedDict(@compat Dict("Apples"=>7))
+    c5 = SortedDict(Dict("Apples"=>7))
     @test !isequal(c4,c5)
     merge!(c1,c2)
     checkcorrectness(c1.bt, false)
@@ -540,7 +539,7 @@ function test3{T}(z::T)
     zero1 = zero(z)
     one1 = one(z)
     two1 = one1 + one1
-    m1 = SortedDict(@compat Dict{T,T}())
+    m1 = SortedDict(Dict{T,T}())
     N = 1000
     for l = 1 : N
         lUi = convert(T, l)
@@ -549,7 +548,7 @@ function test3{T}(z::T)
     count = 0
     for (stok,k,v) in semitokens(inclusive(m1, startof(m1), endof(m1)))
         for (stok2,k2,v2) in semitokens(exclusive(m1, startof(m1), pastendsemitoken(m1)))
-            c = compare(m1,stok,stok2) 
+            c = compare(m1,stok,stok2)
             if c < 0
                 @test deref_key((m1,stok)) < deref_key((m1,stok2))
             elseif c == 0
@@ -561,7 +560,7 @@ function test3{T}(z::T)
         end
     end
     @test eltype(semitokens(exclusive(m1, startof(m1), pastendsemitoken(m1)))) ==
-    @compat Tuple{IntSemiToken, T, T}
+    Tuple{IntSemiToken, T, T}
     @test count == N^2
     N = 10000
     sk = zero1
@@ -596,7 +595,7 @@ function test3{T}(z::T)
     end
     @test eltype(keys(m1)) == T
     @test sk2 == sk
-    
+
     sk2a = zero1
 
 
@@ -606,28 +605,28 @@ function test3{T}(z::T)
     @test eltype(eachindex(m1)) == T
     @test sk2a == sk
 
-    
+
 
     sk2b = zero1
     for st in onlysemitokens(m1)
         sk2b += deref_key((m1,st))
     end
     @test sk2b == sk
-    
+
     sv2 = zero1
     for v in values(m1)
         sv2 += v
     end
     @test eltype(values(m1)) == T
-    
+
     @test sv == sv2
     count = 0
     for (st,k) in semitokens(keys(m1))
         @test deref_key((m1,st)) == k
         count += 1
     end
-    @test eltype(semitokens(keys(m1))) == @compat Tuple{IntSemiToken, T}
-    
+    @test eltype(semitokens(keys(m1))) == Tuple{IntSemiToken, T}
+
     @test count == N
     count = 0
     for (st,v) in semitokens(values(m1))
@@ -635,7 +634,7 @@ function test3{T}(z::T)
         count += 1
     end
     @test count == N
-    @test eltype(semitokens(values(m1))) == @compat Tuple{IntSemiToken, T}
+    @test eltype(semitokens(values(m1))) == Tuple{IntSemiToken, T}
 
     pos1 = searchsortedfirst(m1, div(N,2))
     sk2 = zero1
@@ -674,7 +673,7 @@ function test3{T}(z::T)
         count += 1
     end
     @test count == 0
-    @test eltype(keys(inclusive(m1, startof(m1), beforestartsemitoken(m1)))) == 
+    @test eltype(keys(inclusive(m1, startof(m1), beforestartsemitoken(m1)))) ==
        T
 
 
@@ -734,28 +733,28 @@ function test3{T}(z::T)
     @test eltype(onlysemitokens(factors)) == IntSemiToken
 
     sum2 = 0
-    for (k,v) in inclusive(factors, 
+    for (k,v) in inclusive(factors,
                            searchsortedfirst(factors,70),
                            searchsortedlast(factors,70))
         sum2 += v
     end
 
     @test sum2 == 1 + 2 + 5 + 7 + 10 + 14 + 35 + 70
-    @test eltype(inclusive(factors, 
+    @test eltype(inclusive(factors,
                            searchsortedfirst(factors,70),
                            searchsortedlast(factors,70))) == tuple_or_pair(Int,Int)
 
 
     sum2 = 0
-    for st in eachindex(inclusive(factors, 
+    for st in eachindex(inclusive(factors,
                                   searchsortedfirst(factors,70),
                                   searchsortedlast(factors,70)))
         v = deref_value((factors,st))
         sum2 += v
     end
-    
+
     @test sum2 == 1 + 2 + 5 + 7 + 10 + 14 + 35 + 70
-    @test eltype(eachindex(inclusive(factors, 
+    @test eltype(eachindex(inclusive(factors,
                                      searchsortedfirst(factors,70),
                                      searchsortedlast(factors,70)))) == IntSemiToken
 
@@ -763,25 +762,25 @@ function test3{T}(z::T)
 
     sum3 = 0
     for (k,v) in exclusive(factors,
-                           searchsortedfirst(factors,60), 
+                           searchsortedfirst(factors,60),
                            searchsortedfirst(factors,61))
         sum3 += v
     end
     @test sum3 == 1 + 2 + 3 + 4 + 5 + 6 + 10 + 12 + 15 + 20 + 30 + 60
-    @test eltype(exclusive(factors, 
+    @test eltype(exclusive(factors,
                            searchsortedfirst(factors,70),
                            searchsortedlast(factors,70))) == tuple_or_pair(Int,Int)
 
 
     sum3 = 0
     for st in eachindex(exclusive(factors,
-                                  searchsortedfirst(factors,60), 
+                                  searchsortedfirst(factors,60),
                                   searchsortedfirst(factors,61)))
         v = deref_value((factors,st))
         sum3 += v
     end
     @test sum3 == 1 + 2 + 3 + 4 + 5 + 6 + 10 + 12 + 15 + 20 + 30 + 60
-    @test eltype(eachindex(exclusive(factors, 
+    @test eltype(eachindex(exclusive(factors,
                                      searchsortedfirst(factors,70),
                                      searchsortedlast(factors,70)))) == IntSemiToken
 
@@ -815,16 +814,16 @@ function test3{T}(z::T)
                                 searchsortedfirst(factors,70),
                                 searchsortedlast(factors,70)))) ==  Int
 
-    
+
     sum3 = 0
     for k in keys(exclusive(factors,
-                            searchsortedfirst(factors,60), 
+                            searchsortedfirst(factors,60),
                             searchsortedfirst(factors,61)))
         sum3 += k
     end
     @test sum3 == 60 * 12
     @test eltype(keys(exclusive(factors,
-                                searchsortedfirst(factors,60), 
+                                searchsortedfirst(factors,60),
                                 searchsortedfirst(factors,61)))) == Int
 
 
@@ -837,18 +836,18 @@ function test3{T}(z::T)
     end
     @test sum2 == 1 + 2 + 5 + 7 + 10 + 14 + 35 + 70
     @test eltype(values(inclusive(factors,
-                                  searchsortedfirst(factors,60), 
+                                  searchsortedfirst(factors,60),
                                   searchsortedfirst(factors,61)))) == Int
-    
+
     sum3 = 0
     for v in values(exclusive(factors,
-                              searchsortedfirst(factors,60), 
+                              searchsortedfirst(factors,60),
                               searchsortedfirst(factors,61)))
         sum3 += v
     end
     @test sum3 == 1 + 2 + 3 + 4 + 5 + 6 + 10 + 12 + 15 + 20 + 30 + 60
     @test eltype(values(exclusive(factors,
-                                  searchsortedfirst(factors,60), 
+                                  searchsortedfirst(factors,60),
                                   searchsortedfirst(factors,61)))) == Int
 
     sum1b = 0
@@ -859,7 +858,7 @@ function test3{T}(z::T)
         sum2b += v
     end
     @test sum1b == sum1a && sum2b == sum2a
-    @test eltype(semitokens(factors)) == @compat Tuple{IntSemiToken, Int, Int}
+    @test eltype(semitokens(factors)) == Tuple{IntSemiToken, Int, Int}
 
     sum2 = 0
     for (st,k,v) in semitokens(inclusive(factors,
@@ -872,28 +871,28 @@ function test3{T}(z::T)
     @test eltype(semitokens(inclusive(factors,
                                          searchsortedfirst(factors,70),
                                          searchsortedlast(factors,70)))) ==
-        @compat Tuple{IntSemiToken, Int, Int}
-    
+        Tuple{IntSemiToken, Int, Int}
+
     sum3 = 0
     for (st,k,v) in semitokens(exclusive(factors,
-                                         searchsortedfirst(factors,60), 
+                                         searchsortedfirst(factors,60),
                                          searchsortedfirst(factors,61)))
         @test deref_value((factors,st)) == v
         sum3 += v
     end
     @test sum3 == 1 + 2 + 3 + 4 + 5 + 6 + 10 + 12 + 15 + 20 + 30 + 60
     @test eltype(semitokens(exclusive(factors,
-                                      searchsortedfirst(factors,60), 
+                                      searchsortedfirst(factors,60),
                                       searchsortedfirst(factors,61)))) ==
-         @compat Tuple{IntSemiToken, Int, Int}
-    
+         Tuple{IntSemiToken, Int, Int}
+
     sum4 = 0
     for (st,k) in semitokens(keys(factors))
         @test deref_key((factors,st)) == k && mod(k,deref_value((factors,st))) == 0
         sum4 += k
     end
     @test sum4 == sum1
-    @test eltype(semitokens(keys(factors))) == @compat Tuple{IntSemiToken,Int}
+    @test eltype(semitokens(keys(factors))) == Tuple{IntSemiToken,Int}
 
     sum5 = 0
     for (st,v) in semitokens(values(factors))
@@ -901,7 +900,7 @@ function test3{T}(z::T)
         sum5 += v
     end
     @test sum5 == sum2a
-    @test eltype(semitokens(values(factors))) == @compat Tuple{IntSemiToken,Int}
+    @test eltype(semitokens(values(factors))) == Tuple{IntSemiToken,Int}
 
     sum2 = 0
     for (st,k) in semitokens(keys(inclusive(factors,
@@ -914,20 +913,20 @@ function test3{T}(z::T)
     @test eltype(semitokens(keys(inclusive(factors,
                                            searchsortedfirst(factors,70),
                                            searchsortedlast(factors,70))))) ==
-        @compat Tuple{IntSemiToken, Int}
-    
+        Tuple{IntSemiToken, Int}
+
     sum3 = 0
     for (st,k) in semitokens(keys(inclusive(factors,
-                                            searchsortedfirst(factors,60), 
+                                            searchsortedfirst(factors,60),
                                             searchsortedlast(factors,60))))
         @test deref_key((factors,st)) == k && mod(k,deref_value((factors,st))) == 0
         sum3 += k
     end
     @test sum3 == 60 * 12
     @test eltype(semitokens(keys(inclusive(factors,
-                                            searchsortedfirst(factors,60), 
+                                            searchsortedfirst(factors,60),
                                             searchsortedlast(factors,60))))) ==
-        @compat Tuple{IntSemiToken, Int}
+        Tuple{IntSemiToken, Int}
 
     sum2 = 0
     for (st,v) in semitokens(values(inclusive(factors,
@@ -940,21 +939,21 @@ function test3{T}(z::T)
     @test eltype(semitokens(values(inclusive(factors,
                                               searchsortedfirst(factors,70),
                                               searchsortedlast(factors,70))))) ==
-      @compat Tuple{IntSemiToken, Int}
-    
+      Tuple{IntSemiToken, Int}
+
     sum3 = 0
     for (st,v) in semitokens(values(exclusive(factors,
-                                              searchsortedfirst(factors,60), 
+                                              searchsortedfirst(factors,60),
                                               searchsortedfirst(factors,61))))
         @test deref_value((factors,st)) == v
         sum3 += v
     end
     @test sum3 == 1 + 2 + 3 + 4 + 5 + 6 + 10 + 12 + 15 + 20 + 30 + 60
     @test eltype(semitokens(values(exclusive(factors,
-                                              searchsortedfirst(factors,60), 
+                                              searchsortedfirst(factors,60),
                                               searchsortedfirst(factors,61))))) ==
-       @compat Tuple{IntSemiToken, Int}
-    
+       Tuple{IntSemiToken, Int}
+
     s = SortedSet([39, 24, 2, 14, 45, 107, 66])
     sum1 = 0
     for k in s
@@ -968,7 +967,7 @@ function test3{T}(z::T)
         sum1 += k
     end
     @test sum1 == sum([39, 24, 2, 14, 45, 107, 66])
-    @test eltype(semitokens(s)) == @compat Tuple{IntSemiToken, Int}
+    @test eltype(semitokens(s)) == Tuple{IntSemiToken, Int}
 
 
     sum1 = 0
@@ -991,25 +990,25 @@ function test3{T}(z::T)
 
     sum2 = 0
     for k in inclusive(s,
-                       searchsortedfirst(s, 24), 
+                       searchsortedfirst(s, 24),
                        searchsortedfirst(s, 66))
         sum2 += k
     end
     @test sum2 == 24 + 39 + 45 + 66
     @test eltype(inclusive(s,
-                       searchsortedfirst(s, 24), 
+                       searchsortedfirst(s, 24),
                        searchsortedfirst(s, 66))) == Int
 
 
     sum2 = 0
     for st in eachindex(inclusive(s,
-                                  searchsortedfirst(s, 24), 
+                                  searchsortedfirst(s, 24),
                                   searchsortedfirst(s, 66)))
         sum2 += deref((s,st))
     end
     @test sum2 == 24 + 39 + 45 + 66
     @test eltype(eachindex(inclusive(s,
-                                     searchsortedfirst(s, 24), 
+                                     searchsortedfirst(s, 24),
                                      searchsortedfirst(s, 66)))) == IntSemiToken
 
 
@@ -1026,7 +1025,7 @@ function test3{T}(z::T)
     @test eltype(semitokens(inclusive(s,
                                        searchsortedfirst(s, 24),
                                        searchsortedfirst(s, 66)))) ==
-      @compat Tuple{IntSemiToken, Int}
+      Tuple{IntSemiToken, Int}
 
 
     sum2 = 0
@@ -1045,39 +1044,39 @@ function test3{T}(z::T)
 
     sum3 = 0
     for k in exclusive(s,
-                       searchsortedfirst(s, 24), 
+                       searchsortedfirst(s, 24),
                        searchsortedfirst(s, 66))
         sum3 += k
     end
     @test sum3 == 24 + 39 + 45
     @test eltype(exclusive(s,
-                       searchsortedfirst(s, 24), 
+                       searchsortedfirst(s, 24),
                        searchsortedfirst(s, 66))) == Int
-        
+
 
     sum3 = 0
     for (st,k) in semitokens(exclusive(s,
-                                       searchsortedfirst(s, 24), 
+                                       searchsortedfirst(s, 24),
                                        searchsortedfirst(s, 66)))
         @test deref((s,st)) == k
         sum3 += k
     end
     @test sum3 == 24 + 39 + 45
     @test eltype(semitokens(exclusive(s,
-                                       searchsortedfirst(s, 24), 
+                                       searchsortedfirst(s, 24),
                                        searchsortedfirst(s, 66)))) ==
-     @compat Tuple{IntSemiToken, Int}
+     Tuple{IntSemiToken, Int}
 
 
     sum3 = 0
     for st in eachindex(exclusive(s,
-                                  searchsortedfirst(s, 24), 
+                                  searchsortedfirst(s, 24),
                                   searchsortedfirst(s, 66)))
         sum3 += deref((s,st))
     end
     @test sum3 == 24 + 39 + 45
     @test eltype(eachindex(exclusive(s,
-                                     searchsortedfirst(s, 24), 
+                                     searchsortedfirst(s, 24),
                                      searchsortedfirst(s, 66)))) == IntSemiToken
     nothing
 end
@@ -1087,9 +1086,9 @@ end
 
 function test4()
     # test all the errors of sorted containers
-    m = SortedDict(@compat Dict("a" => 6, "bb" => 9))
+    m = SortedDict(Dict("a" => 6, "bb" => 9))
     @test_throws KeyError println(m["b"])
-    m2 = SortedDict(@compat Dict{ASCIIString, Int}())
+    m2 = SortedDict(Dict{ASCIIString, Int}())
     @test_throws BoundsError println(first(m2))
     @test_throws BoundsError println(last(m2))
     state1 = start(m2)
@@ -1101,7 +1100,7 @@ function test4()
     @test_throws BoundsError start(exclusive(m,i1,i2))
     @test_throws KeyError delete!(m,"a")
     @test_throws KeyError pop!(m,"a")
-    m3 = SortedDict((@compat Dict{ASCIIString, Int}()), Reverse)
+    m3 = SortedDict((Dict{ASCIIString, Int}()), Reverse)
     @test_throws ErrorException isequal(m2, m3)
     @test_throws BoundsError m[i1]
     @test_throws BoundsError regress((m,beforestartsemitoken(m)))
@@ -1146,7 +1145,7 @@ function test5()
     ## Test use of alternative orderings in test5
     keylist = ["Apple", "aPPle", "berry", "CHerry", "Dairy", "diary"]
     vallist = [6,9,-4,2,1,8]
-    m = SortedDict(@compat Dict{ASCIIString,Int}())
+    m = SortedDict(Dict{ASCIIString,Int}())
     for j = 1:6
         m[keylist[j]] = vallist[j]
     end
@@ -1155,11 +1154,11 @@ function test5()
     count = 0
     for p in m
         count += 1
-        @test p[1] == keylist[expectedord1[count]] && 
+        @test p[1] == keylist[expectedord1[count]] &&
                 p[2] == vallist[expectedord1[count]]
     end
     @test count == 6
-    m2 = SortedDict((@compat Dict{ASCIIString, Int}()), Reverse)
+    m2 = SortedDict((Dict{ASCIIString, Int}()), Reverse)
     for j = 1 : 6
         m2[keylist[j]] = vallist[j]
     end
@@ -1168,11 +1167,11 @@ function test5()
     count = 0
     for p in m2
         count += 1
-        @test p[1] == keylist[expectedord2[count]] && 
+        @test p[1] == keylist[expectedord2[count]] &&
                 p[2] == vallist[expectedord2[count]]
     end
     @test count == 6
-    m3 = SortedDict((@compat Dict{ASCIIString, Int}()), CaseInsensitive())
+    m3 = SortedDict((Dict{ASCIIString, Int}()), CaseInsensitive())
     for j = 1 : 6
         m3[keylist[j]] = vallist[j]
     end
@@ -1191,7 +1190,7 @@ function test5()
     @test eltype(m3empty) == tuple_or_pair(ASCIIString, Int) &&
        orderobject(m3empty) == CaseInsensitive() &&
        length(m3empty) == 0
-    m4 = SortedDict((@compat Dict{ASCIIString,Int}()), Lt((x,y) -> isless(lowercase(x),lowercase(y))))
+    m4 = SortedDict((Dict{ASCIIString,Int}()), Lt((x,y) -> isless(lowercase(x),lowercase(y))))
     for j = 1 : 6
         m4[keylist[j]] = vallist[j]
     end
@@ -1205,7 +1204,7 @@ function test5()
     @test count == 5
     nothing
 end
-    
+
 
 ## test6, test6a and test6b are not run by package
 ## testing but are included for timing tests.
@@ -1213,7 +1212,7 @@ end
 
 function test6(numtrial::Int, expectedk::ASCIIString, expectedd::ASCIIString)
     NSTRINGPAIR = 50000
-    m1 = SortedDict(@compat Dict{ASCIIString,ASCIIString}())
+    m1 = SortedDict(Dict{ASCIIString,ASCIIString}())
     strlist = ASCIIString[]
     open(seekfile("wordsScram.txt"), "r") do inio
         for j = 1 : NSTRINGPAIR * 2
@@ -1250,7 +1249,7 @@ end
 
 function test6a(numtrial::Int, expectedk::ASCIIString, expectedd::ASCIIString)
     NSTRINGPAIR = 50000
-    m1 = SortedDict((@compat Dict{ASCIIString, ASCIIString}()), Lt(isless))
+    m1 = SortedDict((Dict{ASCIIString, ASCIIString}()), Lt(isless))
     strlist = ASCIIString[]
     open(seekfile("wordsScram.txt"), "r") do inio
         for j = 1 : NSTRINGPAIR * 2
@@ -1293,10 +1292,10 @@ function SDConstruct(a::Associative; lt::Function=isless, by::Function=identity)
     end
 end
 
-    
+
 function test6b(numtrial::Int, expectedk::ASCIIString, expectedd::ASCIIString)
     NSTRINGPAIR = 50000
-    m1 = SDConstruct((@compat Dict{ASCIIString,ASCIIString}()), lt=isless)
+    m1 = SDConstruct((Dict{ASCIIString,ASCIIString}()), lt=isless)
     strlist = ASCIIString[]
     open(seekfile("wordsScram.txt"), "r") do inio
         for j = 1 : NSTRINGPAIR * 2
@@ -1433,7 +1432,7 @@ function test7()
     @test compare(factors,regress((factors,i)),i2) == 0
     @test !isempty(factors)
     empty!(factors)
-    checkcorrectness(factors.bt, true) 
+    checkcorrectness(factors.bt, true)
     @test length(factors) == 0
     @test isempty(factors)
     i = startof(factors)
@@ -1468,7 +1467,7 @@ function test7()
     checkcorrectness(m6.bt, true)
     @test isequal(m1,m6)
 
-    m1 = SortedMultiDict(["bananas", "apples", "cherries", "cherries", "oranges"], 
+    m1 = SortedMultiDict(["bananas", "apples", "cherries", "cherries", "oranges"],
                          [1.0, 2.0, 3.0, 4.0, 5.0])
     m2 = SortedMultiDict(["apples", "cherries", "cherries", "bananas", "plums"],
                          [6.0, 7.0, 8.0, 9.0, 10.0])
@@ -1513,7 +1512,7 @@ function test7()
     end
     nothing
 end
-    
+
 
 function test8()
     # Test SortedSet
@@ -1664,8 +1663,8 @@ function test8()
     setdiff!(m8, SortedSet(["yellow", "red", "white"]))
     @test isequal(m8, SortedSet(["blue", "orange"]))
     nothing
-end    
-               
+end
+
 
 # test the constructors of SortedDict and SortedMultiDict
 

--- a/test/test_trie.jl
+++ b/test/test_trie.jl
@@ -23,7 +23,7 @@ kvs = collect(zip(ks, vs))
 @test typeof(Trie(ks, vs)) == Trie{Int}
 @test typeof(Trie(kvs)) == Trie{Int}
 @test typeof(Trie(Dict(kvs))) == Trie{Int}
-@test typeof(Trie(ks)) == @compat Trie{Void}
+@test typeof(Trie(ks)) == Trie{Void}
 
 
 # path iterator


### PR DESCRIPTION
This subsumes #146, and further removes all uses of `@compat`.  

Closes #145 

Will merge tonight or tomorrow (PST) if there are no comments.