### PR TITLE
RFC: Delete deprecation warnings

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -87,17 +87,4 @@ module DataStructures
     export status
     export deref_key, deref_value, deref, advance, regress
 
-    @deprecate stack Stack
-    @deprecate queue Queue
-    @deprecate add! push!
-
-    @deprecate HashDict{K,V}(ks::AbstractArray{K}, vs::AbstractArray{V}) HashDict{K,V,Unordered}(ks,vs)
-    @deprecate HashDict(ks, vs) HashDict{Any,Any,Unordered}(ks, vs)
-
-    @deprecate OrderedDict(ks, vs) OrderedDict(zip(ks,vs))
-    @deprecate OrderedDict{K,V}(ks::AbstractArray{K}, vs::AbstractArray{V}) OrderedDict{K,V}(zip(ks,vs))
-    @deprecate OrderedDict{K,V}(::Type{K},::Type{V}) OrderedDict{K,V}()
-
-    @deprecate OrderedSet(a, b...) OrderedSet(Any[a, b...])
-    @deprecate OrderedSet{T<:Number}(xs::T...)  OrderedSet{T}(xs)      # (almost) mimic Set deprecation in Base
 end


### PR DESCRIPTION
* The latest of these was added 8 months ago, which is probably long
  enough for most packages to adapt
* The corresponding deprecations in Julia itself have been removed
* In the future, these should include the specific DataStructures/
  julia version when added and/or when to remove