### PR TITLE
Fix OrderedDict constructors (fixes #148)

### DIFF
--- a/src/hashdict.jl
+++ b/src/hashdict.jl
@@ -5,13 +5,8 @@ import Base: KeyIterator, ValueIterator, haskey, get, getkey, delete!,
              sizehint, length, filter, isempty, start, next, done,
              keys, values, _tablesz, skip_deleted, serialize, deserialize
 
-if VERSION < v"0.4.0-dev+5152"
-    import Base: serialize_type
-    const SerState = IO
-else
-    import Base.Serializer: serialize_type
-    const SerState =  Base.Serializer.SerializationState
-end
+import Base.Serializer: serialize_type
+const SerState =  Base.Serializer.SerializationState
 
 typealias Unordered Void
 typealias Ordered   Int
@@ -30,22 +25,20 @@ type HashDict{K,V,O<:Union{Ordered,Unordered}} <: Associative{K,V}
         n = 16
         new(zeros(UInt8,n), Array(K,n), Array(V,n), Array(O,n), Array(O,0), 0, 0, identity)
     end
-    if VERSION >= v"0.4.0-dev+980"
-        HashDict(p::Pair) = setindex!(HashDict{K,V,O}(), p.second, p.first)
-        function HashDict(ps::Pair{K,V}...)
-            h = HashDict{K,V,O}()
-            sizehint(h, length(ps))
-            for p in ps
-                h[p.first] = p.second
-            end
-            return h
+
+    HashDict(p::Pair) = setindex!(HashDict{K,V,O}(), p.second, p.first)
+    function HashDict(ps::Pair...)
+        h = HashDict{K,V,O}()
+        sizehint(h, length(ps))
+        for p in ps
+            h[p.first] = p.second
         end
-        HashDict(p::Pair{K,V}) = invoke(HashDict, (Pair{K,V}...), p)
+        return h
     end
+
     function HashDict(ks, vs)
-        if VERSION >= v"0.4.0-dev+980"
-            Base.warn_once("HashDict(kv,vs) is deprecated, use HashDict(zip(ks,vs)) instead")
-        end
+        Base.warn_once("HashDict(kv,vs) is deprecated, use HashDict(zip(ks,vs)) instead")
+
         n = length(ks)
         h = HashDict{K,V,O}()
         for i=1:n
@@ -53,6 +46,7 @@ type HashDict{K,V,O<:Union{Ordered,Unordered}} <: Associative{K,V}
         end
         return h
     end
+
     function HashDict(kv)
         h = HashDict{K,V,O}()
         sizehint(h, length(kv))

--- a/src/ordereddict.jl
+++ b/src/ordereddict.jl
@@ -21,6 +21,7 @@ immutable OrderedDict{K,V} <: Associative{K,V}
     OrderedDict() = new(HashDict{K,V,Ordered}())
     OrderedDict(kv) = new(HashDict{K,V,Ordered}(kv))
     OrderedDict(ps::Pair{K,V}...) = new(HashDict{K,V,Ordered}(ps...))
+    OrderedDict(ps::Pair...) = new(HashDict{K,V,Ordered}(ps...))
     #OrderedDict(ks,vs) = new(HashDict{K,V,Ordered}(ks,vs))
 end
 
@@ -33,6 +34,7 @@ ordered_dict_with_eltype{K,V}(kv, ::Type{Pair{K,V}})  = OrderedDict{K,V}(kv)
 ordered_dict_with_eltype(kv, t)                       = OrderedDict{Any,Any}(kv)
 
 OrderedDict{K,V}(ps::Pair{K,V}...)                     = OrderedDict{K,V}(ps...)
+OrderedDict(ps::Pair...)                               = OrderedDict{Any,Any}(ps...)
 OrderedDict{K,V}(kv::Tuple{Vararg{Pair{K,V}}})         = OrderedDict{K,V}(kv)
 OrderedDict{K}(kv::Tuple{Vararg{Pair{K}}})             = OrderedDict{K,Any}(kv)
 OrderedDict{V}(kv::Tuple{Vararg{Pair{TypeVar(:K),V}}}) = OrderedDict{Any,V}(kv)

--- a/test/test_ordereddict.jl
+++ b/test/test_ordereddict.jl
@@ -313,3 +313,20 @@ let
     @test dd == od
     close(s)
 end
+
+# #148
+
+let d148 = OrderedDict(
+                 :gps => [],
+                 :direction => 1:8,
+                 :weather => 1:10
+          ),
+    d148_2 = OrderedDict(
+           :time => 1:10,
+           :features => OrderedDict(
+               :gps => 1:5,
+               :direction => 1:8,
+               :weather => 1:10
+           )
+       )
+end


### PR DESCRIPTION
* Add more generic version of construction from Pairs, to allow
  mixed type Pairs
* Relax type constraints on HashDict (which is used as the basis
  for OrderedDict), to allow mixed type Pairs