### PR TITLE
Add hash and == for Deque.

### DIFF
--- a/src/deque.jl
+++ b/src/deque.jl
@@ -271,3 +271,20 @@ function shift!{T}(q::Deque{T})  # pop front
     q.len -= 1
     x
 end
+
+const _deque_hashseed = UInt === UInt64 ? 0x950aa17a3246be82 : 0x4f26f881
+function hash(x::Deque, h::UInt)
+    h += _deque_hashseed
+    for (i, x) in enumerate(x)
+        h += i * hash(x)
+    end
+    h
+end
+
+function ==(x::Deque, y::Deque)
+    length(x) != length(y) && return false
+    for (i, j) in zip(x, y)
+        i == j || return false
+    end
+    true
+end

--- a/test/test_deque.jl
+++ b/test/test_deque.jl
@@ -152,6 +152,23 @@ for k = 1 : m
     @test collect(q) == r
 end
 
+# hash and ==
+a = Deque{Int64}(2)
+b = Deque{Int64}(3)
+# Note: blksize does not distinguish == or hash
+@test a == b
+@test hash(a) === hash(b)
+push!(a, 1)
+@test a != b
+push!(a, 2)
+push!(b, 2, 1)
+@test a != b
+@test hash(a) !== hash(b)
+shift!(b)
+push!(b, 2)
+@test a == b
+@test hash(a) == hash(b)
+
 # issue #38
 
 q = Deque{Int}(1)


### PR DESCRIPTION
fixes #152.

Also offers a hash.

Both of these are different if the blksize is different. Perhaps this is not desired?