### PR TITLE
RFC: change type to hide implementation

### DIFF
--- a/src/queue.jl
+++ b/src/queue.jl
@@ -1,7 +1,7 @@
 # FIFO queue
 
-type Queue{S}   # S is the type of internal deque
-    store::S
+type Queue{T}
+    store::Deque{T}
 end
 
 Queue{T}(ty::Type{T}) = Queue(Deque{T}())
@@ -20,7 +20,7 @@ end
 
 dequeue!(s::Queue) = shift!(s.store)
 
-function iter{T}(q::Queue{Deque{T}})
+function iter{T}(q::Queue{T})
     a = T[]
     for i in q.store
         push!(a,i)

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -1,7 +1,7 @@
 # stacks
 
-type Stack{S}   # S is the type of the internal dequeue instance
-    store::S
+type Stack{T}
+    store::Deque{T}
 end
 
 Stack{T}(ty::Type{T}) = Stack(Deque{T}())
@@ -18,7 +18,7 @@ function push!(s::Stack, x)
 end
 
 #returns a collection that can be used in a for loop
-function iter{T}(s::Stack{Deque{T}})
+function iter{T}(s::Stack{T})
     a = T[]
     for i in s.store
         unshift!(a,i)
@@ -27,5 +27,3 @@ function iter{T}(s::Stack{Deque{T}})
 end
 
 pop!(s::Stack) = pop!(s.store)
-
-

--- a/test/test_stack_and_queue.jl
+++ b/test/test_stack_and_queue.jl
@@ -8,6 +8,7 @@ using Base.Test
 s = Stack(Int, 5)
 n = 100
 
+@test typeof(s) == Stack{Int}
 @test length(s) == 0
 @test isempty(s)
 @test_throws ErrorException top(s)
@@ -52,6 +53,7 @@ iterated = iter(stk)
 s = Queue(Int, 5)
 n = 100
 
+@test typeof(s) == Queue{Int}
 @test length(s) == 0
 @test isempty(s)
 @test_throws ErrorException front(s)


### PR DESCRIPTION
This is a resubmission of #98, which I was too slow to merge before.  It's a minor change, and if there's reason not to do this, it can easily be reverted later.  But it's a small step in the right direction to cleaning up `Stack` and `Queue` (and `Deque`) types.

(Original PR from @andrewcooke; he still owns the commit.)