### PR TITLE
RFC: Use "throw" with a specific exception instead of "error()"

### DIFF
--- a/src/defaultdict.jl
+++ b/src/defaultdict.jl
@@ -19,7 +19,7 @@ immutable DefaultDictBase{K,V,F,D} <: Associative{K,V}
     d::D
 
     check_D(D,K,V) = (D <: Associative{K,V}) ||
-        error("Default dict must be <: Associative{K,V}")
+        throw(ArgumentError("Default dict must be <: Associative{K,V}"))
 
     DefaultDictBase(x::F, kv::AbstractArray{Tuple{K,V}}) = (check_D(D,K,V); new(x, D(kv)))
     DefaultDictBase(x::F, ps::Pair{K,V}...) = (check_D(D,K,V); new(x, D(ps...)))
@@ -31,8 +31,8 @@ end
 
 # Constructors
 
-DefaultDictBase() = error("no default specified")
-DefaultDictBase(k,v) = error("no default specified")
+DefaultDictBase() = throw(ArgumentError("no default specified"))
+DefaultDictBase(k,v) = throw(ArgumentError("no default specified"))
 
 # TODO: these mimic similar Dict constructors, but may not be needed
 DefaultDictBase{K,V,F}(default::F, ks::AbstractArray{K}, vs::AbstractArray{V}) =
@@ -82,8 +82,8 @@ for (DefaultDict,O) in [(:DefaultDict, :Unordered), (:DefaultOrderedDict, :Order
 
         ## Constructors
 
-        $DefaultDict() = error("$DefaultDict: no default specified")
-        $DefaultDict(k,v) = error("$DefaultDict: no default specified")
+        $DefaultDict() = throw(ArgumentError("$DefaultDict: no default specified"))
+        $DefaultDict(k,v) = throw(ArgumentError("$DefaultDict: no default specified"))
 
         # TODO: these mimic similar Dict constructors, but may not be needed
         $DefaultDict{K,V,F}(default::F, ks::AbstractArray{K}, vs::AbstractArray{V}) = $DefaultDict{K,V,F}(default,ks,vs)
@@ -125,8 +125,8 @@ end
 
 ## Constructors
 
-# DefaultSortedDict() = error("DefaultSortedDict: no default specified")
-# DefaultSortedDict(k,v) = error("DefaultSortedDict: no default specified")
+# DefaultSortedDict() = throw(ArgumentError("DefaultSortedDict: no default specified"))
+# DefaultSortedDict(k,v) = throw(ArgumentError("DefaultSortedDict: no default specified"))
 
 # # TODO: these mimic similar Dict constructors, but may not be needed
 # DefaultSortedDict{K,V,F}(default::F, ks::AbstractArray{K}, vs::AbstractArray{V}) = DefaultSortedDict{K,V,F}(default,ks,vs)

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -78,13 +78,13 @@ length(q::Deque) = q.len
 num_blocks(q::Deque) = q.nblocks
 
 function front(q::Deque)
-    isempty(q) && error("Attempted to front at an empty deque.")
+    isempty(q) && throw(ArgumentError("Deque must be non-empty"))
     blk = q.head
     blk.data[blk.front]
 end
 
 function back(q::Deque)
-    isempty(q) && error("Attempted to back at an empty deque.")
+    isempty(q) && throw(ArgumentError("Deque must be non-empty"))
     blk = q.rear
     blk.data[blk.back]
 end
@@ -232,7 +232,7 @@ function unshift!{T}(q::Deque{T}, x)   # push front
 end
 
 function pop!{T}(q::Deque{T})   # pop back
-    isempty(q) && error("Attempted to pop from an empty deque.")
+    isempty(q) && throw(ArgumentError("Deque must be non-empty"))
     rear = q.rear
     @assert rear.back >= rear.front
 
@@ -253,7 +253,7 @@ end
 
 
 function shift!{T}(q::Deque{T})  # pop front
-    isempty(q) && error("Attempted to pop from an empty deque.")
+    isempty(q) && throw(ArgumentError("Deque must be non-empty"))
     head = q.head
     @assert head.back >= head.front
 

--- a/src/hashdict.jl
+++ b/src/hashdict.jl
@@ -380,7 +380,7 @@ end
 function setindex!{K,V}(h::HashDict{K,V}, v0, key0)
     key = convert(K,key0)
     if !isequal(key,key0)
-        error(key0, " is not a valid key for type ", K)
+        throw(ArgumentError("$key0 is not a valid key for type $K"))
     end
     v   = convert(V,  v0)
 
@@ -398,7 +398,7 @@ end
 function get!{K,V}(h::HashDict{K,V}, key0, default)
     key = convert(K,key0)
     if !isequal(key,key0)
-        error(key0, " is not a valid key for type ", K)
+        throw(ArgumentError("$key0 is not a valid key for type $K"))
     end
 
     index = ht_keyindex2(h, key)
@@ -413,7 +413,7 @@ end
 function get!{K,V}(h::HashDict{K,V}, key0, default)
     key = convert(K,key0)
     if !isequal(key,key0)
-        error(key0, " is not a valid key for type ", K)
+        throw(ArgumentError("$key0 is not a valid key for type $K"))
     end
 
     index = ht_keyindex2(h, key)
@@ -429,7 +429,7 @@ end
 function get!{K,V,F<:Base.Callable}(h::HashDict{K,V}, key0, default::F)
     key = convert(K,key0)
     if !isequal(key,key0)
-        error(key0, " is not a valid key for type ", K)
+        throw(ArgumentError("$key0 is not a valid key for type $K"))
     end
 
     index = ht_keyindex2(h, key)

--- a/src/sortedDict.jl
+++ b/src/sortedDict.jl
@@ -225,7 +225,7 @@ end
 function isequal(m1::SortedDict, m2::SortedDict)
     ord = orderobject(m1)
     if !isequal(ord, orderobject(m2)) || !isequal(eltype(m1), eltype(m2))
-        error("Cannot use isequal for two SortedDicts unless their element types and ordering objects are equal")
+        throw(ArgumentError("Cannot use isequal for two SortedDicts unless their element types and ordering objects are equal"))
     end
     p1 = startof(m1)
     p2 = startof(m2)

--- a/test/test_defaultdict.jl
+++ b/test/test_defaultdict.jl
@@ -3,8 +3,8 @@
 ##############
 
 # construction
-@test_throws ErrorException DefaultDict()
-@test_throws ErrorException DefaultDict(AbstractString, Int)
+@test_throws ArgumentError DefaultDict()
+@test_throws ArgumentError DefaultDict(AbstractString, Int)
 
 @test typeof(DefaultDict(0.0, 1 => 1.0)) == DefaultDict{Int,Float64,Float64}
 
@@ -64,8 +64,8 @@ s = similar(d)
 #####################
 
 # construction
-@test_throws ErrorException DefaultOrderedDict()
-@test_throws ErrorException DefaultOrderedDict(AbstractString, Int)
+@test_throws ArgumentError DefaultOrderedDict()
+@test_throws ArgumentError DefaultOrderedDict(AbstractString, Int)
 
 # empty dictionary
 d = DefaultOrderedDict(Char, Int, 1)

--- a/test/test_deque.jl
+++ b/test/test_deque.jl
@@ -8,8 +8,8 @@ q = Deque{Int}()
 @test length(q) == 0
 @test isempty(q)
 @test q.blksize == DataStructures.DEFAULT_DEQUEUE_BLOCKSIZE
-@test_throws ErrorException front(q)
-@test_throws ErrorException back(q)
+@test_throws ArgumentError front(q)
+@test_throws ArgumentError back(q)
 @test length(sprint(dump,q)) >= 0
 
 @test typeof(deque(Int)) == typeof(Deque{Int}())
@@ -25,8 +25,8 @@ q = Deque{Int}(3)
 @test isempty(q)
 @test q.blksize == 3
 @test num_blocks(q) == 1
-@test_throws ErrorException front(q)
-@test_throws ErrorException back(q)
+@test_throws ArgumentError front(q)
+@test_throws ArgumentError back(q)
 @test isa(collect(q), Vector{Int})
 @test collect(q) == Int[]
 
@@ -67,8 +67,8 @@ for i = 1 : n
         @test front(q) == 1
         @test back(q) == n - i
     else
-        @test_throws ErrorException front(q)
-        @test_throws ErrorException back(q)
+        @test_throws ArgumentError front(q)
+        @test_throws ArgumentError back(q)
     end
 
     cq = collect(q)
@@ -106,8 +106,8 @@ for i = 1 : n
         @test front(q) == n - i
         @test back(q) == 1
     else
-        @test_throws ErrorException front(q)
-        @test_throws ErrorException back(q)
+        @test_throws ArgumentError front(q)
+        @test_throws ArgumentError back(q)
     end
 
     cq = collect(q)

--- a/test/test_intset.jl
+++ b/test/test_intset.jl
@@ -114,7 +114,7 @@ s = IntSet(1:2:10)
 @test_throws KeyError pop!(s, 1)
 @test_throws ArgumentError pop!(s, -1)
 @test_throws ArgumentError pop!(s, -1, 1)
-@test_throws ArgumentError pop!(()->error(), s, -1)
+@test_throws ArgumentError pop!(()->throw(ErrorException()), s, -1)
 @test pop!(s, 1, 0) == 0
 @test s === delete!(s, 1)
 for i in s; pop!(s, i); end
@@ -123,7 +123,7 @@ x = 0
 @test 1 == pop!(()->(global x; x+=1), s, 100)
 @test x == 1
 push!(s, 100)
-@test pop!(()->error(), s, 100) == 100
+@test pop!(()->throw(ErrorException()), s, 100) == 100
 push!(s, 1:2:10...)
 @test pop!(s) == 9
 @test pop!(s) == 7
@@ -139,7 +139,7 @@ c = complement(IntSet())
 @test_throws KeyError pop!(c, 1)
 @test_throws ArgumentError pop!(c, -1)
 @test_throws ArgumentError pop!(c, -1, 1)
-@test_throws ArgumentError pop!(()->error(), c, -1)
+@test_throws ArgumentError pop!(()->throw(ErrorException()), c, -1)
 @test pop!(c, 1, 0) == 0
 @test c === delete!(c, 1)
 @test shift!(c) == 0

--- a/test/test_sortedcontainers.jl
+++ b/test/test_sortedcontainers.jl
@@ -100,20 +100,20 @@ function checkcorrectness{K,D,Ord <: Ordering}(t::DataStructures.BalancedTree23{
             c1 = t.tree[anc].child1
             if in(c1, intree)
                 println("anc = $anc c1 = $c1")
-                error("Tree contains loops 1")
+                throw(ErrorException("Tree contains loops 1"))
             end
             push!(bfstreenodes, c1)
             push!(intree, c1)
             c2 = t.tree[anc].child2
             if in(c2, intree)
-                error("Tree contains loops 2")
+                throw(ErrorException("Tree contains loops 2"))
             end
             push!(bfstreenodes, c2)
             push!(intree, c2)
             c3 = t.tree[anc].child3
             if c3 > 0
                 if in(c3, intree)
-                    error("Tree contains loops 3")
+                    throw(ErrorException("Tree contains loops 3"))
                 end
                 push!(bfstreenodes, c3)
                 push!(intree, c3)
@@ -129,7 +129,7 @@ function checkcorrectness{K,D,Ord <: Ordering}(t::DataStructures.BalancedTree23{
         c1 = t.tree[anc].child1
         if s == levstart[tdpth]
             if c1 != 1
-                error("Leftmost data descendant should be node 1")
+                throw(ErrorException("Leftmost data descendant should be node 1"))
             end
         else
             minkeys[s] = t.data[c1].k
@@ -139,7 +139,7 @@ function checkcorrectness{K,D,Ord <: Ordering}(t::DataStructures.BalancedTree23{
         lastchild = c3 > 0? c3 : c2
         if s == bfstreesize
             if lastchild != 2
-                error("Rightmost data descendant should be node 2")
+                throw(ErrorException("Rightmost data descendant should be node 2"))
             end
         else
             maxkeys[s] = t.data[lastchild].k
@@ -150,16 +150,16 @@ function checkcorrectness{K,D,Ord <: Ordering}(t::DataStructures.BalancedTree23{
             println("tdpth = ", tdpth, " s = ", s,
                     " maxkeys[s-1] = ", maxkeys[s-1],
                     " minkeys[s] = ", minkeys[s])
-            error("Data nodes out of order")
+            throw(ErrorException("Data nodes out of order"))
         end
         if s < bfstreesize || c3 > 0
             if !eq(t.ord, t.tree[anc].splitkey1, t.data[c2].k)
-                error("Splitkey1 of leaf should match key of 2nd child")
+                throw(ErrorException("Splitkey1 of leaf should match key of 2nd child"))
             end
         end
         if s < bfstreesize && c3 > 0
             if !eq(t.ord, t.tree[anc].splitkey2, t.data[c3].k)
-                error("Splitkey2 of leaf should match key of 1st child")
+                throw(ErrorException("Splitkey2 of leaf should match key of 1st child"))
             end
         end
         if t.data[c1].parent != anc || t.data[c2].parent != anc ||
@@ -169,7 +169,7 @@ function checkcorrectness{K,D,Ord <: Ordering}(t::DataStructures.BalancedTree23{
             if c3 > 0
                 println("t.data[c3].parent = $(t.data[c3].parent)")
             end
-            error("Incorrect parent node for data child")
+            throw(ErrorException("Incorrect parent node for data child"))
         end
         push!(dataused, c1)
         push!(dataused, c2)
@@ -188,21 +188,21 @@ function checkcorrectness{K,D,Ord <: Ordering}(t::DataStructures.BalancedTree23{
             end
             cp += 1
             if t.tree[c1].parent != anc
-                error("Parent/child1 links do not match")
+                throw(ErrorException("Parent/child1 links do not match"))
             end
             c2 = t.tree[anc].child2
             @assert(c2 == bfstreenodes[cp])
             mk2 = minkeys[cp]
             cp += 1
             if t.tree[c2].parent != anc
-                error("Parent/child2 links do not match")
+                throw(ErrorException("Parent/child2 links do not match"))
             end
             c3 = t.tree[anc].child3
             @assert(s == levstart[curdepth] ||
                     lt(t.ord,mk1,mk2) || (!lt(t.ord,mk2,mk1) && allowdups))
             if c3 > 0
                 if t.tree[c3].parent != anc
-                    error("Parent/child3 links do not match")
+                    throw(ErrorException("Parent/child3 links do not match"))
                 end
                 mk3 = minkeys[cp]
                 cp += 1
@@ -213,10 +213,10 @@ function checkcorrectness{K,D,Ord <: Ordering}(t::DataStructures.BalancedTree23{
                 minkeys[s] = mk1
             end
             if !eq(t.ord, t.tree[anc].splitkey1, mk2)
-                error("Minkey2 not equal to minimum key among descendants of child2")
+                throw(ErrorException("Minkey2 not equal to minimum key among descendants of child2"))
             end
             if c3 > 0 && !eq(t.ord, t.tree[anc].splitkey2, mk3)
-                error("Minkey3 not equal to minimum key among descendants of child3")
+                throw(ErrorException("Minkey3 not equal to minimum key among descendants of child3"))
             end
         end
     end
@@ -224,41 +224,41 @@ function checkcorrectness{K,D,Ord <: Ordering}(t::DataStructures.BalancedTree23{
     for i = 1 : size(t.freedatainds,1)
         fdi = t.freedatainds[i]
         if in(fdi, freedata)
-            error("t.freedatainds has repeated element $i")
+            throw(ErrorException("t.freedatainds has repeated element $i"))
         end
         if fdi < 1 || fdi > dsz
-            error("t.freedatainds entry out of range")
+            throw(ErrorException("t.freedatainds entry out of range"))
         end
         push!(freedata, fdi)
     end
     if last(t.useddatacells) > dsz
-        error("t.useddatacells has indices larger than t.data size")
+        throw(ErrorException("t.useddatacells has indices larger than t.data size"))
     end
     for i = 1 : dsz
         if (in(i, dataused) && !in(i, t.useddatacells)) ||
             (!in(i,dataused) && in(i, t.useddatacells))
-            error("Mismatch between actual data cells used and useddatacells array")
+            throw(ErrorException("Mismatch between actual data cells used and useddatacells array"))
         end
         if (in(i, freedata) && in(i, dataused)) ||
             (!in(i,freedata) && !in(i, dataused))
-            error("Mismatch between t.freedatainds and t.useddatacells")
+            throw(ErrorException("Mismatch between t.freedatainds and t.useddatacells"))
         end
     end
     freetree = IntSet()
     for i = 1 : size(t.freetreeinds,1)
         tfi = t.freetreeinds[i]
         if in(tfi, freetree)
-            error("Free tree index repeated twice")
+            throw(ErrorException("Free tree index repeated twice"))
         end
         if tfi < 1 || tfi > tsz
-            error("Free tree index out of range")
+            throw(ErrorException("Free tree index out of range"))
         end
         push!(freetree, tfi)
     end
     for i = 1 : tsz
         if (!in(i, intree) && !in(i, freetree)) ||
             (in(i, intree) && in(i, freetree))
-            error("Mismatch between t.freetreeinds and actual cells used")
+            throw(ErrorException("Mismatch between t.freetreeinds and actual cells used"))
         end
     end
 end
@@ -1098,7 +1098,7 @@ function test4()
     @test_throws KeyError delete!(m,"a")
     @test_throws KeyError pop!(m,"a")
     m3 = SortedDict((Dict{ASCIIString, Int}()), Reverse)
-    @test_throws ErrorException isequal(m2, m3)
+    @test_throws ArgumentError isequal(m2, m3)
     @test_throws BoundsError m[i1]
     @test_throws BoundsError regress((m,beforestartsemitoken(m)))
     @test_throws BoundsError advance((m,pastendsemitoken(m)))
@@ -1285,7 +1285,7 @@ function SDConstruct(a::Associative; lt::Function=isless, by::Function=identity)
     elseif lt == isless
         return SortedDict(a, By(by))
     else
-        error("having both by and lt not both implemented")
+        throw(ErrorException("having both by and lt not both implemented"))
     end
 end
 

--- a/test/test_stack_and_queue.jl
+++ b/test/test_stack_and_queue.jl
@@ -8,8 +8,8 @@ n = 100
 @test typeof(s) == Stack{Int}
 @test length(s) == 0
 @test isempty(s)
-@test_throws ErrorException top(s)
-@test_throws ErrorException pop!(s)
+@test_throws ArgumentError top(s)
+@test_throws ArgumentError pop!(s)
 
 for i = 1 : n
     push!(s, i)
@@ -24,7 +24,7 @@ for i = 1 : n
     if i < n
         @test top(s) == n - i
     else
-        @test_throws ErrorException top(s)
+        @test_throws ArgumentError top(s)
     end
     @test isempty(s) == (i == n)
     @test length(s) == n - i
@@ -53,9 +53,9 @@ n = 100
 @test typeof(s) == Queue{Int}
 @test length(s) == 0
 @test isempty(s)
-@test_throws ErrorException front(s)
-@test_throws ErrorException back(s)
-@test_throws ErrorException dequeue!(s)
+@test_throws ArgumentError front(s)
+@test_throws ArgumentError back(s)
+@test_throws ArgumentError dequeue!(s)
 
 for i = 1 : n
     enqueue!(s, i)
@@ -72,8 +72,8 @@ for i = 1 : n
         @test front(s) == i + 1
         @test back(s) == n
     else
-        @test_throws ErrorException front(s)
-        @test_throws ErrorException back(s)
+        @test_throws ArgumentError front(s)
+        @test_throws ArgumentError back(s)
     end
     @test isempty(s) == (i == n)
     @test length(s) == n - i


### PR DESCRIPTION
Cleaning up `error` functions.

In cases where the correct exception seemed ambiguous (e.g., `pop!` on an empty `Deque`), I followed conventions in `Base`.