### PR TITLE
In Julia 0.4: sizehint => sizehint! (and sizehint is deprecated).  Fixes #119.

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -6,7 +6,7 @@ module DataStructures
                  show, dump, empty!, getindex, setindex!, get, get!,
                  in, haskey, keys, merge, copy, cat,
                  push!, pop!, shift!, unshift!, insert!,
-                 union!, delete!, similar, sizehint,
+                 union!, delete!, similar, sizehint!,
                  isequal, hash,
                  map, reverse,
                  first, last, eltype, getkey, values, sum,
@@ -19,7 +19,7 @@ module DataStructures
 
     export Deque, Stack, Queue
     export deque, enqueue!, dequeue!, update!,iter
-    export capacity, num_blocks, front, back, top, sizehint
+    export capacity, num_blocks, front, back, top, sizehint!
 
     export Accumulator, counter
     export ClassifiedCollections

--- a/src/defaultdict.jl
+++ b/src/defaultdict.jl
@@ -49,7 +49,7 @@ DefaultDictBase{F,D<:Associative}(default::F, d::D) = ((K,V)=eltype(d); DefaultD
 # Functions
 
 # most functions are simply delegated to the wrapped dictionary
-@delegate DefaultDictBase.d [ sizehint, empty!, setindex!, get, haskey,
+@delegate DefaultDictBase.d [ sizehint!, empty!, setindex!, get, haskey,
                              getkey, pop!, delete!, start, done, next,
                              isempty, length ]
 
@@ -100,7 +100,7 @@ for (DefaultDict,O) in [(:DefaultDict, :Unordered), (:DefaultOrderedDict, :Order
         ## Functions
 
         # Most functions are simply delegated to the wrapped DefaultDictBase object
-        @delegate $DefaultDict.d [ sizehint, empty!, setindex!,
+        @delegate $DefaultDict.d [ sizehint!, empty!, setindex!,
                                    getindex, get, get!, haskey,
                                    getkey, pop!, delete!, start, next,
                                    done, isempty, length ]
@@ -143,7 +143,7 @@ end
 
 ## Most functions are simply delegated to the wrapped DefaultDictBase object
 
-# @delegate DefaultSortedDict.d [ sizehint, empty!, setindex!,
+# @delegate DefaultSortedDict.d [ sizehint!, empty!, setindex!,
 #                            getindex, get, get!, haskey,
 #                            getkey, pop!, delete!, start, next,
 #                            done, isempty, length]

--- a/src/hashdict.jl
+++ b/src/hashdict.jl
@@ -2,7 +2,7 @@
 
 import Base: KeyIterator, ValueIterator, haskey, get, getkey, delete!,
              pop!, empty!, filter!, setindex!, getindex, similar,
-             sizehint, length, filter, isempty, start, next, done,
+             sizehint!, length, filter, isempty, start, next, done,
              keys, values, _tablesz, skip_deleted, serialize, deserialize
 
 import Base.Serializer: serialize_type
@@ -29,7 +29,7 @@ type HashDict{K,V,O<:Union{Ordered,Unordered}} <: Associative{K,V}
     HashDict(p::Pair) = setindex!(HashDict{K,V,O}(), p.second, p.first)
     function HashDict(ps::Pair...)
         h = HashDict{K,V,O}()
-        sizehint(h, length(ps))
+        sizehint!(h, length(ps))
         for p in ps
             h[p.first] = p.second
         end
@@ -49,7 +49,7 @@ type HashDict{K,V,O<:Union{Ordered,Unordered}} <: Associative{K,V}
 
     function HashDict(kv)
         h = HashDict{K,V,O}()
-        sizehint(h, length(kv))
+        sizehint!(h, length(kv))
         for (k,v) in kv
             h[k] = v
         end
@@ -94,7 +94,7 @@ end
 
 function deserialize{K,V,O}(s::SerState, T::Type{HashDict{K,V,O}})
     n = deserialize(s)
-    t = T(); sizehint(t, n)
+    t = T(); sizehint!(t, n)
     for i = 1:n
         k = deserialize(s)
         v = deserialize(s)
@@ -254,7 +254,7 @@ function _compact_order{K,V}(h::HashDict{K,V,Ordered})
     nothing
 end
 
-function sizehint(d::HashDict, newsz)
+function sizehint!(d::HashDict, newsz)
     oldsz = length(d.slots)
     if newsz <= oldsz
         # todo: shrink

--- a/src/heaps.jl
+++ b/src/heaps.jl
@@ -22,7 +22,7 @@
 #
 #   - push!(h, v)       add a value to the heap
 #
-#   - sizehint(h)       set size hint to a heap
+#   - sizehint!(h)       set size hint to a heap
 #
 #   - top(h)            return the top value of a heap
 #

--- a/src/intset.jl
+++ b/src/intset.jl
@@ -24,7 +24,7 @@ function copy!(to::IntSet, from::IntSet)
     to
 end
 eltype(s::IntSet) = Int
-sizehint(s::IntSet, n::Integer) = (_resize0!(s.bits, n+1); s)
+sizehint!(s::IntSet, n::Integer) = (_resize0!(s.bits, n+1); s)
 
 # only required on 0.3:
 function first(itr::IntSet)

--- a/src/multidict.jl
+++ b/src/multidict.jl
@@ -49,7 +49,7 @@ end
                         getindex, length, isempty, eltype,
                         start, next, done, keys, values]
 
-sizehint(d::MultiDict, sz::Integer) = (sizehint(d.d, sz); d)
+sizehint!(d::MultiDict, sz::Integer) = (sizehint!(d.d, sz); d)
 copy(d::MultiDict) = MultiDict(d)
 similar{K,V}(d::MultiDict{K,V}) = MultiDict{K,V}()
 ==(d1::MultiDict, d2::MultiDict) = d1.d == d2.d

--- a/src/ordereddict.jl
+++ b/src/ordereddict.jl
@@ -52,7 +52,7 @@ copy(d::OrderedDict) = OrderedDict(d)
                          length, isempty, start, next, done, keys,
                          values ]
 
-sizehint(d::OrderedDict, sz::Integer) = (sizehint(d.d, sz); d)
+sizehint!(d::OrderedDict, sz::Integer) = (sizehint!(d.d, sz); d)
 
 push!(d::OrderedDict, kv::Pair) = (push!(d.d, kv); d)
 push!(d::OrderedDict, kv::Pair, kv2::Pair) = (push!(d.d, kv, kv2); d)

--- a/src/orderedset.jl
+++ b/src/orderedset.jl
@@ -19,7 +19,7 @@ show(io::IO, s::OrderedSet) = (show(io, typeof(s)); print(io, "("); !isempty(s) 
 
 @delegate OrderedSet.dict [isempty, length]
 
-sizehint(s::OrderedSet, sz::Integer) = (sizehint(s.dict, sz); s)
+sizehint!(s::OrderedSet, sz::Integer) = (sizehint!(s.dict, sz); s)
 eltype{T}(s::OrderedSet{T}) = T
 
 in(x, s::OrderedSet) = haskey(s.dict, x)

--- a/test/test_intset.jl
+++ b/test/test_intset.jl
@@ -34,7 +34,7 @@ s = IntSet([0,1,10,20,200,300,1000,10000,10002])
 @test_throws ArgumentError first(IntSet())
 @test_throws ArgumentError last(IntSet())
 t = copy(s)
-sizehint(t, 20000) #check that hash does not depend on size of internal Array{UInt32, 1}
+sizehint!(t, 20000) #check that hash does not depend on size of internal Array{UInt32, 1}
 @test hash(s) == hash(t)
 @test hash(complement(s)) == hash(complement(t))
 
@@ -73,7 +73,7 @@ copy!(c2, c1)
 c3 = copy(c2)
 c4 = complement(s1)
 @test c1 == c2 == c3 == c4
-@test c4 === sizehint(c4, 100)
+@test c4 === sizehint!(c4, 100)
 @test c1 == c4
 @test last(c1) == typemax(Int)-1
 @test last(complement(IntSet())) == typemax(Int)-1

--- a/test/test_ordereddict.jl
+++ b/test/test_ordereddict.jl
@@ -235,7 +235,7 @@ d3[data_in[rand(1:length(data_in))][1]] = randstring(3)
 d4[1001] = randstring(3)
 @test !isequal(d1, d4)
 
-@test isequal(OrderedDict(), sizehint(OrderedDict(),96))
+@test isequal(OrderedDict(), sizehint!(OrderedDict(),96))
 
 # Here is what currently happens when dictionaries of different types
 # are compared. This is not necessarily desirable. These tests are

--- a/test/test_orderedset.jl
+++ b/test/test_orderedset.jl
@@ -84,9 +84,9 @@ push!(c,200)
 @test !in(100,c)
 @test !in(200,s)
 
-# sizehint, empty
+# sizehint!, empty
 s = OrderedSet([1])
-@test isequal(sizehint(s, 10), OrderedSet([1]))
+@test isequal(sizehint!(s, 10), OrderedSet([1]))
 @test isequal(empty!(s), OrderedSet())
 # TODO: rehash
 


### PR DESCRIPTION
This is simply a search and replace. 

The deprecation for `sizehint` is actually handled by the definition in `Base`.

Should not be controversial.  Will merge soon.