### PR TITLE
use standard iterator for Stack + Queue Fixes #116

### DIFF
--- a/doc/source/stack_and_queue.rst
+++ b/doc/source/stack_and_queue.rst
@@ -4,7 +4,7 @@
 Stack and Queue
 -----------------
 
-The ``Stack`` and ``Queue`` types are a light-weight wrapper of a deque type, which respectively provide interfaces for FILO and FIFO access.
+The ``Stack`` and ``Queue`` types are a light-weight wrapper of a deque type, which respectively provide interfaces for LIFO and FIFO access.
 
 Usage of Stack::
 
@@ -20,3 +20,5 @@ Usage of Queue::
   x = front(q)
   x = back(q)
   x = dequeue!(q)
+
+Both ``Stack`` and ``Queue`` implement the Iterator interface; iterating over ``Stack`` returns items in FILO order and iterating over ``Queue`` returns items in FIFO order. There is also a ``reverse_iter`` function implemented for both which returns items in the reverse order for each type (i.e. FIFO for ``Stack`` and LIFO for ``Queue``).

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -18,7 +18,7 @@ module DataStructures
 
 
     export Deque, Stack, Queue
-    export deque, enqueue!, dequeue!, update!,iter
+    export deque, enqueue!, dequeue!, update!
     export capacity, num_blocks, front, back, top, sizehint!
 
     export Accumulator, counter

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -18,7 +18,7 @@ module DataStructures
 
 
     export Deque, Stack, Queue
-    export deque, enqueue!, dequeue!, update!
+    export deque, enqueue!, dequeue!, update!, reverse_iter
     export capacity, num_blocks, front, back, top, sizehint!
 
     export Accumulator, counter
@@ -94,4 +94,6 @@ module DataStructures
     export status
     export deref_key, deref_value, deref, advance, regress
 
+    @deprecate iter(s::Stack) s
+    @deprecate iter(q::Queue) q
 end

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -20,6 +20,10 @@ end
 
 dequeue!(s::Queue) = shift!(s.store)
 
+# Iterators
+
 start(q::Queue) = start(q.store)
-next(q::Queue,i) = next(q.store, i)
-done(q::Queue,i) = done(q.store, i)
+next(q::Queue, s) = next(q.store, s)
+done(q::Queue, s) = done(q.store, s)
+
+reverse_iter(q::Queue) = reverse_iter(q.store)

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -20,10 +20,6 @@ end
 
 dequeue!(s::Queue) = shift!(s.store)
 
-function iter{T}(q::Queue{T})
-    a = T[]
-    for i in q.store
-        push!(a,i)
-    end
-    return a
-end
+start(q::Queue) = start(q.store)
+next(q::Queue,i) = next(q.store, i)
+done(q::Queue,i) = done(q.store, i)

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -17,13 +17,8 @@ function push!(s::Stack, x)
     s
 end
 
-#returns a collection that can be used in a for loop
-function iter{T}(s::Stack{T})
-    a = T[]
-    for i in s.store
-        unshift!(a,i)
-    end
-    return a
-end
+start(s::Stack) = start(s.store)
+next(s::Stack,i) = next(s.store, i)
+done(s::Stack,i) = done(s.store, i)
 
 pop!(s::Stack) = pop!(s.store)

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -17,8 +17,10 @@ function push!(s::Stack, x)
     s
 end
 
-start(s::Stack) = start(s.store)
-next(s::Stack,i) = next(s.store, i)
-done(s::Stack,i) = done(s.store, i)
-
 pop!(s::Stack) = pop!(s.store)
+
+start(st::Stack) = start(reverse_iter(st.store))
+next(st::Stack, s) = next(reverse_iter(st.store), s)
+done(st::Stack, s) = done(reverse_iter(st.store), s)
+
+reverse_iter{T}(s::Stack{T}) = DequeIterator{T}(s.store)

--- a/test/test_stack_and_queue.jl
+++ b/test/test_stack_and_queue.jl
@@ -41,8 +41,12 @@ for i = 1:n
     push!(arr,i)
 end
 
-iterated = iter(stk)
-@test(reverse(arr) == iterated)
+#test iterator
+index = length(arr)
+for i in q
+  @test(arr[index] == i)
+  index -= 1
+end
 
 
 # Queue
@@ -90,5 +94,9 @@ for i = 1:n
     push!(arr,i)
 end
 
-iterated = iter(q)
-@test(arr == iterated)
+#test iterator
+index = 1
+for i in q
+  @test(arr[index] == i)
+  index += 1
+end

--- a/test/test_stack_and_queue.jl
+++ b/test/test_stack_and_queue.jl
@@ -42,12 +42,21 @@ for i = 1:n
 end
 
 #test iterator
+
 index = length(arr)
-for i in q
-  @test(arr[index] == i)
-  index -= 1
+for i in stk
+    @test(arr[index] == i)
+    index -= 1
 end
 
+index = 1
+for i in reverse_iter(stk)
+    @test(arr[index] == i)
+    index += 1
+end
+
+@test arr == [i for i in reverse_iter(stk)]
+@test reverse(arr) == [i for i in stk]
 
 # Queue
 
@@ -95,8 +104,18 @@ for i = 1:n
 end
 
 #test iterator
+
 index = 1
 for i in q
-  @test(arr[index] == i)
-  index += 1
+    @test(arr[index] == i)
+    index += 1
 end
+
+index = length(arr)
+for i in reverse_iter(q)
+    @test(arr[index] == i)
+    index -= 1
+end
+
+@test arr == [i for i in q]
+@test reverse(arr) == [i for i in reverse_iter(q)]


### PR DESCRIPTION
@kmsquire

This moves the iterator for stack and queue to conform to iterators such as those in https://github.com/JuliaLang/Iterators.jl

It effectively just calls down and utilizes the iterator for `Deque`