### PR TITLE
move imports to runtests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,7 @@
+using Base.Test
+using DataStructures
+const IntSet = DataStructures.IntSet
+
 tests = ["intset",
          "deque",
          "sortedcontainers",
@@ -13,6 +17,10 @@ tests = ["intset",
          "trie",
          "list",
          "multidict"]
+
+if length(ARGS) > 0
+    tests = ARGS
+end
 
 for t in tests
     fp = joinpath(dirname(@__FILE__), "test_$t.jl")

--- a/test/test_accumulator.jl
+++ b/test/test_accumulator.jl
@@ -1,8 +1,5 @@
 # Test of accumulators
 
-using DataStructures
-using Base.Test
-
 ct = counter(ASCIIString)
 @assert isa(ct, Accumulator{ASCIIString,Int})
 

--- a/test/test_binheap.jl
+++ b/test/test_binheap.jl
@@ -1,8 +1,5 @@
 # Test of binary heaps
 
-using DataStructures
-using Base.Test
-
 # test make heap
 
 vs = [4, 1, 3, 2, 16, 9, 10, 14, 8, 7]

--- a/test/test_defaultdict.jl
+++ b/test/test_defaultdict.jl
@@ -1,6 +1,3 @@
-using DataStructures
-using Base.Test
-
 ##############
 # DefaultDicts
 ##############

--- a/test/test_disjoint_set.jl
+++ b/test/test_disjoint_set.jl
@@ -1,8 +1,5 @@
 # Test disjoint set
 
-using DataStructures
-using Base.Test
-
 s = IntDisjointSets(10)
 
 @test length(s) == 10

--- a/test/test_intset.jl
+++ b/test/test_intset.jl
@@ -1,7 +1,4 @@
 ## IntSet
-using DataStructures
-using Base.Test
-const IntSet = DataStructures.IntSet
 
 # Construction, collect
 data_in = (1,5,100)

--- a/test/test_list.jl
+++ b/test/test_list.jl
@@ -1,5 +1,3 @@
-using DataStructures
-using Base.Test
 
 l0 = nil(Char)
 @test length(l0) == 0

--- a/test/test_multidict.jl
+++ b/test/test_multidict.jl
@@ -1,5 +1,3 @@
-using DataStructures
-using Base.Test
 
 # construction
 KVS = ('a',[1])

--- a/test/test_mutable_binheap.jl
+++ b/test/test_mutable_binheap.jl
@@ -1,8 +1,5 @@
 # Test of binary heaps
 
-using DataStructures
-using Base.Test
-
 # auxiliary functions
 
 function heap_values{VT,Comp}(h::MutableBinaryHeap{VT,Comp})

--- a/test/test_ordereddict.jl
+++ b/test/test_ordereddict.jl
@@ -1,6 +1,3 @@
-using DataStructures
-using Base.Test
-
 # construction
 
 @test typeof(OrderedDict()) == OrderedDict{Any,Any}

--- a/test/test_sortedcontainers.jl
+++ b/test/test_sortedcontainers.jl
@@ -1,4 +1,3 @@
-using DataStructures
 import Base.Ordering
 import Base.Forward
 import Base.Reverse

--- a/test/test_stack_and_queue.jl
+++ b/test/test_stack_and_queue.jl
@@ -1,8 +1,5 @@
 # test stacks and queues
 
-using DataStructures
-using Base.Test
-
 # Stack
 
 s = Stack(Int, 5)
@@ -33,11 +30,11 @@ for i = 1 : n
     @test length(s) == n - i
 end
 
-#test that iter returns a LIFO collection 
+#test that iter returns a LIFO collection
 
 stk = Stack(Int, 10)
 #an array to check iteration sequence against
-arr = Int64[] 
+arr = Int64[]
 
 for i = 1:n
     push!(stk,i)
@@ -82,11 +79,11 @@ for i = 1 : n
     @test length(s) == n - i
 end
 
-#test that iter returns a FIFO collection 
+#test that iter returns a FIFO collection
 
 q = Queue(Int, 10)
 #an array to check iteration sequence against
-arr = Int64[] 
+arr = Int64[]
 
 for i = 1:n
     enqueue!(q,i)

--- a/test/test_trie.jl
+++ b/test/test_trie.jl
@@ -1,6 +1,3 @@
-using DataStructures
-using Base.Test
-
 t=Trie{Int}()
 
 t["amy"]=56


### PR DESCRIPTION
@kmsquire 

this cleans up the tests a bit so that most of the imports are done in `runtests` instead of duplicated across test files