### PR TITLE
For DisjointSets, make union! return the root of the newly merged set

### DIFF
--- a/doc/source/disjoint_sets.rst
+++ b/doc/source/disjoint_sets.rst
@@ -10,7 +10,9 @@ A widely used data structure for this purpose is the *Disjoint set forest*.
 Usage::
 
   a = IntDisjointSets(10)      # creates a forest comprised of 10 singletons
-  union!(a, 3, 5)             # merges the sets that contain 3 and 5 into one
+  union!(a, 3, 5)             # merges the sets that contain 3 and 5 into one and returns the root of the new set
+  root_union!(a, x, y)     # merges the sets that have root x and y into one and returns the root of the new set
+  find_root(a, 3)              # finds the root element of the subset that contains 3
   in_same_set(a, x, y)        # determines whether x and y are in the same set
   elem = push!(a)             # adds a single element in a new set; returns the new element
                               # (this operation is often called MakeSet)
@@ -25,3 +27,4 @@ One may also use other element types::
 
 
 Note that the internal implementation of ``IntDisjointSets`` is based on vectors, and is very efficient. ``DisjointSets{T}`` is a wrapper of ``IntDisjointSets``, which uses a dictionary to map input elements to an internal index.
+Note for ``DisjointSets``, ``union!``, ``root_union!`` and ``find_root`` return the index of the root. 

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -25,7 +25,7 @@ module DataStructures
     export ClassifiedCollections
     export classified_lists, classified_sets, classified_counters
 
-    export IntDisjointSets, DisjointSets, num_groups, find_root, in_same_set
+    export IntDisjointSets, DisjointSets, num_groups, find_root, in_same_set, root_union!
     export push!
 
     export AbstractHeap, compare, extract_all!

--- a/test/test_disjoint_set.jl
+++ b/test/test_disjoint_set.jl
@@ -28,14 +28,17 @@ union!(s, 3, 2)
 @test push!(s) == 11
 @test num_groups(s) == 10
 
-union!(s, 8, 7)
-union!(s, 5, 6)
-union!(s, 8, 5)
+@test union!(s, 8, 7) == 8
+@test union!(s, 5, 6) == 5
+@test union!(s, 8, 5) == 8
 @test num_groups(s) == 7
 @test find_root(s, 6) == 8
 union!(s, 2, 6)
 @test find_root(s, 2) == 8
-
+root1 = find_root(s, 6)
+root2 = find_root(s, 2)
+@test root_union!(s, root1, root2) == 8
+@test union!(s, 5, 6) == 8
 
 s = DisjointSets{Int}(1:10)
 
@@ -60,9 +63,9 @@ r = [find_root(s, i) for i in 1 : 10]
 @test isa(r, Vector{Int})
 @test isequal(r, r0)
 
-union!(s, 1, 4)
-union!(s, 3, 5)
-union!(s, 7, 9)
+@test union!(s, 1, 4) == 1
+@test union!(s, 3, 5) == 1
+@test union!(s, 7, 9) == 7
 
 @test length(s) == 10
 @test num_groups(s) == 2
@@ -81,3 +84,9 @@ r0 = [1, 1, 1, 1, 1, 1, 7, 7, 7, 7, 11]
 r = [find_root(s, i) for i in [1 : 10; 17] ]
 @test isa(r, Vector{Int})
 @test isequal(r, r0)
+
+root1 = find_root(s, 7)
+root2 = find_root(s, 3)
+@test root_union!(s, root1, root2) == 7
+@test find_root(s, 7) == 7
+@test find_root(s, 3) == 7


### PR DESCRIPTION
For `DisjointSets`, it is useful if `union!` can return the root of the newly merged set. 
For example, it is used in implementing elimination tree for sparse factorization.
(See Algorithm 5.1 of [2])

The implementation of `_union!` is based on [1].  
After this merge, we have 

```julia
julia> a = IntDisjointSets(10)
DataStructures.IntDisjointSets([1,2,3,4,5,6,7,8,9,10],[0,0,0,0,0,0,0,0,0,0],10)

julia> union!(a, 3, 5)
3

julia> a
DataStructures.IntDisjointSets([1,2,3,4,3,6,7,8,9,10],[0,0,1,0,0,0,0,0,0,0],9)
```

References: 
[1] Data Structures and Network Algorithms, Robert Tarjan (1983) Chapter 2 
Disjoint Sets [[url]](http://epubs.siam.org/doi/abs/10.1137/1.9781611970265.ch2)
[2] The Role of Elimination Trees in Sparse Factorization, Joseph W.H. Liu [[url]](http://epubs.siam.org/doi/abs/10.1137/0611010)
