### PR TITLE
Julia v0.5, other fixes

### DIFF
--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -4,12 +4,11 @@ type Accumulator{T, V<:Number}
     map::Dict{T,V}
 end
 
-## constructors
+# Constructors
 
 Accumulator{T,V<:Number}(::Type{T}, ::Type{V}) = Accumulator{T,V}(Dict{T,V}())
-counter(T::Type) = Accumulator(T,Int)
 
-Accumulator{T,V<:Number}(dct::Dict{T,V}) = Accumulator{T,V}(copy(dct))
+counter(T::Type) = Accumulator(T,Int)
 counter{T}(dct::Dict{T,Int}) = Accumulator{T,Int}(copy(dct))
 
 """

--- a/src/hashdict.jl
+++ b/src/hashdict.jl
@@ -410,21 +410,6 @@ function get!{K,V}(h::HashDict{K,V}, key0, default)
     return v
 end
 
-function get!{K,V}(h::HashDict{K,V}, key0, default)
-    key = convert(K,key0)
-    if !isequal(key,key0)
-        throw(ArgumentError("$key0 is not a valid key for type $K"))
-    end
-
-    index = ht_keyindex2(h, key)
-
-    index > 0 && return h.vals[index]
-
-    v = convert(V,  default)
-    _setindex!(h, v, key, -index)
-    return v
-end
-
 # TODO: this makes it challenging to have V<:Base.Callable
 function get!{K,V,F<:Base.Callable}(h::HashDict{K,V}, key0, default::F)
     key = convert(K,key0)

--- a/src/ordereddict.jl
+++ b/src/ordereddict.jl
@@ -108,8 +108,6 @@ function convert{K,V}(::Type{OrderedDict{K,V}},d::Associative)
 end
 convert{K,V}(::Type{OrderedDict{K,V}},d::OrderedDict{K,V}) = d
 
-hashindex(key, sz) = ((hash(key)%Int) & (sz-1)) + 1
-
 function rehash!{K,V}(h::OrderedDict{K,V}, newsz = length(h.slots))
     olds = h.slots
     keys = h.keys


### PR DESCRIPTION
Submitted on behalf of @ScottPJones.  @rawls238 @DanielArndt can you guys take a look and merge if acceptable?  I'm being distracted by becoming a father and trying to get back to work.

Copy and paste from https://groups.google.com/forum/#!topic/julia-dev/_A3_HMK4EIw:

While trying to get Gadfly.jl working (and eliminating the many warning messages that come up simply trying to do "using Gadfly" under v0.5),
I ran into the following problem in DataStructures.jl/src/accumulator.jl, that I'd like some guidance on.

The Accumulator type is simply a wrapper around a Dict.
The issue is that in v0.5, there is a warning, because there is an outer constructor defined, which simply takes a dictionary passed as an argument, copies it,
and then calls the inner constructor, however, this also overwrites the inner constructor's method, so it is no longer accessible.

Further down, in the two places where the the Accumulator constructor is used, there are explicit copies, so in fact, the dictionary gets copied twice, unnecessarily.

This seems like a bug, where somebody added the outer Accumulator constructor in order to ensure that a copy was always made, but neglected to remove the copy from places where it was done explicitly.

Should the simple fix of simply removing the outer constructor with the extra copy, which also prevents the overwriting warning be done,
or rather change to using only inner constructors, which force any dictionaries to be passed to always be copied? (IMO, it would be better to leave any copying
up to the caller, and document that the dictionary passed to Accumulator will be modified.

I have already made a branch that fixes this and a couple other bugs, in https://github.com/ScottPJones/DataStructures.jl/tree/spj/fixv05.

I would have submitted a PR, however, due to current circumstances, since DataStructures.jl is in JuliaLang, I am unable to do so.

Scott Paul Jones