### PR TITLE
Fix tests in Julia 0.5

### DIFF
--- a/src/containerloops.jl
+++ b/src/containerloops.jl
@@ -88,6 +88,7 @@ immutable SDMKeyIteration{T <: SDMIterableTypesBase}
 end
 
 eltype(s::SDMKeyIteration) = keytype(extractcontainer(s.base))
+length(s::SDMKeyIteration) = length(extractcontainer(s.base))
 
 
 immutable SDMValIteration{T <: SDMIterableTypesBase}
@@ -95,7 +96,7 @@ immutable SDMValIteration{T <: SDMIterableTypesBase}
 end
 
 eltype(s::SDMValIteration) = valtype(extractcontainer(s.base))
-
+length(s::SDMValIteration) = length(extractcontainer(s.base))
 
 
 immutable SDMSemiTokenIteration{T <: SDMIterableTypesBase}

--- a/src/trie.jl
+++ b/src/trie.jl
@@ -126,3 +126,6 @@ function done(it::TrieIterator, state)
 end
 
 path(t::Trie, str::AbstractString) = TrieIterator(t, str)
+if VERSION >= v"0.5.0-dev+3294"
+    Base.iteratorsize(::Type{TrieIterator}) = Base.SizeUnknown()
+end


### PR DESCRIPTION
- Add `length` functions for SDM iterators
- Add `iteratorsize` iterator trait introduced in https://github.com/JuliaLang/julia/commit/a2ce2309863564aed3fba4f8927d586b11983219