### PR TITLE
sizehint for key/value inner constructor

### DIFF
--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -26,6 +26,7 @@ type OrderedDict{K,V} <: Associative{K,V}
     end
     function OrderedDict(kv)
         h = OrderedDict{K,V}()
+        sizehint!(h, length(kv))
         for (k,v) in kv
             h[k] = v
         end


### PR DESCRIPTION
Was this left out unintentionally?