### PR TITLE
While working on using OrderedDict within NamedArrays, I found that t…

### DIFF
--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -24,19 +24,34 @@ type OrderedDict{K,V} <: Associative{K,V}
     function OrderedDict()
         new(zeros(Int32,16), Array(K,0), Array(V,0), 0, false)
     end
+    function OrderedDict(n::Integer)
+        slotsz = (n*3)>>1
+        new(zeros(Int32,slotsz), Array(K,n), Array(V,n), 0, false)
+    end
     function OrderedDict(kv)
-        h = OrderedDict{K,V}()
+        h = OrderedDict{K,V}(length(kv))
+        n = length(h.slots)
+        i = 0
         for (k,v) in kv
-            h[k] = v
+            i = i + 1
+            index = hashindex(k,n)
+            h.keys[i] = k
+            h.vals[i] = v
+            h.slots[index] = i
         end
         return h
     end
     OrderedDict(p::Pair) = setindex!(OrderedDict{K,V}(), p.second, p.first)
     function OrderedDict(ps::Pair...)
-        h = OrderedDict{K,V}()
-        sizehint!(h, length(ps))
+        h = OrderedDict{K,V}(length(ps))
+        n = length(h.slots)
+        i = 0
         for p in ps
-            h[p.first] = p.second
+            i = i + 1
+            index = hashindex(k,n)
+            h.keys[i] = p.first
+            h.vals[i] = p.second
+            h.slots[index] = i
         end
         return h
     end

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -8,6 +8,7 @@
 @test isa(OrderedDict(Pair(1, 1.0), Pair(2, 2.0), Pair(3, 3.0)), OrderedDict{Int,Float64})
 
 # empty dictionary
+
 d = OrderedDict{Char, Int}()
 @test length(d) == 0
 @test isempty(d)
@@ -19,8 +20,18 @@ d['c'] = 1
 empty!(d)
 @test isempty(d)
 
-# access, modification
+# empty-ish dictionary of specified size
 
+d = OrderedDict{Int, Float32}(4);
+@test d.slots == zeros(Int32, 6)
+@test length(d) == 4
+@test length(d.keys) == 4
+@test length(d.vals) == 4
+@test typeof(d.keys) == Array{Int, 1}
+@test typeof(d.vals) == Array{Float32, 1}
+
+# access, modification
+d = OrderedDict{Char, Int}()
 for c in 'a':'z'
     d[c] = c-'a'+1
 end


### PR DESCRIPTION
…he creation of new OrderedDicts was one of the slower parts of NamedArray subsetting. This PR creates an inner constructor for making a new, empty OrderedDict of a specified size. As this new OrderedDict is known to be empty and of the correct size, it can be filled in a simplified fashion. This is good for a 1.6X speedup for creating an OrderedDict with 1e3 key/value pairs. Also, added tests for new constructor of empty-ish OrderedDict of a specified size.