### PR TITLE
WIP: Refactor Sorted Containers

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,3 @@
-julia 0.4
+julia 0.5-
+AbstractTrees
+Iterators

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -1,4 +1,4 @@
-__precompile__()
+#__precompile__()
 
 module DataStructures
 

--- a/src/container_loops.jl
+++ b/src/container_loops.jl
@@ -1,325 +1,45 @@
+using Iterators
+
 import Base.keys
 import Base.values
 
-## These are the containers that can be looped over
-## The prefix SDM is for SortedDict and SortedMultiDict
-## The prefix SS is for SortedSet.  The prefix SA
-## is for all sorted containers.
-## The following two definitions now appear in tokens2.jl
-
-#typealias SDMContainer Union{SortedDict, SortedMultiDict}
-#typealias SAContainer Union{SDMContainer, SortedSet}
-
-@inline extractcontainer(s::SAContainer) = s
-
-## This holds an object describing an exclude-last
-## iteration.
-
-
-abstract AbstractExcludeLast{ContainerType <: SAContainer}
-
-immutable SDMExcludeLast{ContainerType <: SDMContainer} <:
-                              AbstractExcludeLast{ContainerType}
-    m::ContainerType
-    first::Int
-    pastlast::Int
+# Helper
+immutable RangeIterator{T,S}
+    it::T
+    start::S
+    stop::S
 end
+start(r::RangeIterator) = r.start
+next(r::RangeIterator, state) = next(r.it, state)
+done(r::RangeIterator, state) = state == r.stop
 
-immutable SSExcludeLast{ContainerType <: SortedSet} <:
-                              AbstractExcludeLast{ContainerType}
-    m::ContainerType
-    first::Int
-    pastlast::Int
+# Iterate over elements
+element_it(m::SAContainer, it = Leaves(m.bt)) = imap(it) do st
+    node = st.tree.data[st.idx]
+    node.k => node.d
 end
-
-@inline extractcontainer(s::AbstractExcludeLast) = s.m
-eltype(s::AbstractExcludeLast) = eltype(s.m)
-
-## This holds an object describing an include-last
-## iteration.
-
-abstract AbstractIncludeLast{ContainerType <: SAContainer}
-
-
-
-immutable SDMIncludeLast{ContainerType <: SDMContainer} <:
-                               AbstractIncludeLast{ContainerType}
-    m::ContainerType
-    first::Int
-    last::Int
-end
-
-
-immutable SSIncludeLast{ContainerType <: SortedSet} <:
-                               AbstractIncludeLast{ContainerType}
-    m::ContainerType
-    first::Int
-    last::Int
-end
-
-@inline extractcontainer(s::AbstractIncludeLast) = s.m
-eltype(s::AbstractIncludeLast) = eltype(s.m)
-
-
-## The basic iterations are either over the whole sorted container, an
-## exclude-last object or include-last object.
-
-typealias SDMIterableTypesBase Union{SDMContainer,
-                                     SDMExcludeLast,
-                                     SDMIncludeLast}
-
-typealias SSIterableTypesBase Union{SortedSet,
-                                    SSExcludeLast,
-                                    SSIncludeLast}
-
-
-typealias SAIterableTypesBase Union{SAContainer,
-                                    AbstractExcludeLast,
-                                    AbstractIncludeLast}
-
-
-## The compound iterations are obtained by applying keys(..) or values(..)
-## to the basic iterations of the SDM.. type.
-## Furthermore, semitokens(..) can be applied
-## to either a basic iteration or a keys/values iteration.
-
-immutable SDMKeyIteration{T <: SDMIterableTypesBase}
-    base::T
-end
-
-eltype(s::SDMKeyIteration) = keytype(extractcontainer(s.base))
-length(s::SDMKeyIteration) = length(extractcontainer(s.base))
-
-
-immutable SDMValIteration{T <: SDMIterableTypesBase}
-    base::T
-end
-
-eltype(s::SDMValIteration) = valtype(extractcontainer(s.base))
-length(s::SDMValIteration) = length(extractcontainer(s.base))
-
-
-immutable SDMSemiTokenIteration{T <: SDMIterableTypesBase}
-    base::T
-end
-
-eltype(s::SDMSemiTokenIteration) = Tuple{IntSemiToken,
-                                         keytype(extractcontainer(s.base)),
-                                         valtype(extractcontainer(s.base))}
-
-immutable SSSemiTokenIteration{T <: SSIterableTypesBase}
-    base::T
-end
-
-eltype(s::SSSemiTokenIteration) = Tuple{IntSemiToken,
-                                        eltype(extractcontainer(s.base))}
-
-
-immutable SDMSemiTokenKeyIteration{T <: SDMIterableTypesBase}
-    base::T
-end
-
-eltype(s::SDMSemiTokenKeyIteration) = Tuple{IntSemiToken,
-                                            keytype(extractcontainer(s.base))}
-
-immutable SAOnlySemiTokensIteration{T <: SAIterableTypesBase}
-    base::T
-end
-
-eltype(::SAOnlySemiTokensIteration) = IntSemiToken
-
-
-immutable SDMSemiTokenValIteration{T <: SDMIterableTypesBase}
-    base::T
-end
-
-eltype(s::SDMSemiTokenValIteration) = Tuple{IntSemiToken,
-                                            valtype(extractcontainer(s.base))}
-
-typealias SACompoundIterable Union{SDMKeyIteration,
-                                   SDMValIteration,
-                                   SDMSemiTokenIteration,
-                                   SSSemiTokenIteration,
-                                   SDMSemiTokenKeyIteration,
-                                   SDMSemiTokenValIteration,
-                                   SAOnlySemiTokensIteration}
-
-@inline extractcontainer(s::SACompoundIterable) = extractcontainer(s.base)
-
-
-typealias SAIterable Union{SAIterableTypesBase, SACompoundIterable}
-
-
-## All the loops maintain a state which is an object of the
-## following type.
-
-immutable SAIterationState
-    next::Int
-    final::Int
-end
-
-
-## All the loops have the same method for 'done'
-
-@inline done(::SAIterable, state::SAIterationState) = state.next == state.final
-
-
-@inline exclusive{T <: SDMContainer}(m::T, ii::(Tuple{IntSemiToken,IntSemiToken})) =
-    SDMExcludeLast(m, ii[1].address, ii[2].address)
-
-@inline exclusive{T <: SortedSet}(m::T, ii::(Tuple{IntSemiToken,IntSemiToken})) =
-    SSExcludeLast(m, ii[1].address, ii[2].address)
-
-@inline exclusive{T <: SAContainer}(m::T, i1::IntSemiToken, i2::IntSemiToken) =
-    exclusive(m, (i1,i2))
-
-@inline inclusive{T <: SDMContainer}(m::T, ii::(Tuple{IntSemiToken,IntSemiToken})) =
-    SDMIncludeLast(m, ii[1].address, ii[2].address)
-
-@inline inclusive{T <: SortedSet}(m::T, ii::(Tuple{IntSemiToken,IntSemiToken})) =
-    SSIncludeLast(m, ii[1].address, ii[2].address)
-
-@inline inclusive{T <: SAContainer}(m::T, i1::IntSemiToken, i2::IntSemiToken) =
-    inclusive(m, (i1,i2))
-
-
-
-# Next definition needed to break ambiguity with keys(Associative) from Dict.jl
-
-@inline keys{K, D, Ord <: Ordering}(ba::SortedDict{K,D,Ord}) = SDMKeyIteration(ba)
-@inline keys{T <: SDMIterableTypesBase}(ba::T) = SDMKeyIteration(ba)
-
-
-in{K,D,Ord <: Ordering}(k, keyit::SDMKeyIteration{SortedDict{K,D,Ord}}) =
-    haskey(extractcontainer(keyit.base), k)
-
-in{K,D,Ord <: Ordering}(k, keyit::SDMKeyIteration{SortedMultiDict{K,D,Ord}}) =
-    haskey(extractcontainer(keyit.base), k)
-
-
-
-# Next definition needed to break ambiguity with values(Associative) from Dict.jl
-@inline values{K, D, Ord <: Ordering}(ba::SortedDict{K,D,Ord}) = SDMValIteration(ba)
-@inline values{T <: SDMIterableTypesBase}(ba::T) = SDMValIteration(ba)
-@inline semitokens{T <: SDMIterableTypesBase}(ba::T) = SDMSemiTokenIteration(ba)
-@inline semitokens{T <: SSIterableTypesBase}(ba::T) = SSSemiTokenIteration(ba)
-@inline semitokens{T <: SDMIterableTypesBase}(ki::SDMKeyIteration{T}) =
-                   SDMSemiTokenKeyIteration(ki.base)
-@inline semitokens{T <: SDMIterableTypesBase}(vi::SDMValIteration{T}) =
-                   SDMSemiTokenValIteration(vi.base)
-@inline onlysemitokens{T <: SAIterableTypesBase}(ba::T) = SAOnlySemiTokensIteration(ba)
-
-
-
-@inline start(m::SAContainer) = SAIterationState(nextloc0(m.bt,1), 2)
-@inline start(e::SACompoundIterable) = start(e.base)
-
-function start(e::AbstractExcludeLast)
-    (!(e.first in e.m.bt.useddatacells) || e.first == 1 ||
-        !(e.pastlast in e.m.bt.useddatacells)) &&
-        throw(BoundsError())
-    if compareInd(e.m.bt, e.first, e.pastlast) < 0
-        return SAIterationState(e.first, e.pastlast)
-    else
-        return SAIterationState(2, 2)
-    end
-end
-
-function start(e::AbstractIncludeLast)
-    (!(e.first in e.m.bt.useddatacells) || e.first == 1 ||
-        !(e.last in e.m.bt.useddatacells) || e.last == 2) &&
-        throw(BoundsError())
-    if compareInd(e.m.bt, e.first, e.last) <= 0
-        return SAIterationState(e.first, nextloc0(e.m.bt, e.last))
-    else
-        return SAIterationState(2, 2)
-    end
-end
-
-
-## The 'next' function returns different objects depending on whether
-## it is a basic iteration, a key iteration, a values iterations,
-## a semitokens/basic iteration, a semitokens/key iteration, or semitokens/values
-## iteration.
-
-@inline function next(u::SAOnlySemiTokensIteration, state::SAIterationState)
-    sn = state.next
-    (sn < 3 || !(sn in extractcontainer(u).bt.useddatacells)) && throw(BoundsError())
-    IntSemiToken(sn),
-    SAIterationState(nextloc0(extractcontainer(u).bt, sn), state.final)
-end
-
-
-@inline function nexthelper(u, state::SAIterationState)
-    sn = state.next
-    (sn < 3 || !(sn in extractcontainer(u).bt.useddatacells)) && throw(BoundsError())
-    extractcontainer(u).bt.data[sn], sn,
-    SAIterationState(nextloc0(extractcontainer(u).bt, sn), state.final)
-end
-
-
-
-
-
-@inline function next(u::SDMIterableTypesBase, state::SAIterationState)
-    dt, t, ni = nexthelper(u, state)
-    (dt.k => dt.d), ni
-end
-
-
-@inline function next(u::SSIterableTypesBase, state::SAIterationState)
-    dt, t, ni = nexthelper(u, state)
-    dt.k, ni
-end
-
-
-@inline function next(u::SDMKeyIteration, state::SAIterationState)
-    dt, t, ni = nexthelper(u, state)
-    dt.k, ni
-end
-
-@inline function next(u::SDMValIteration, state::SAIterationState)
-    dt, t, ni = nexthelper(u, state)
-    dt.d, ni
-end
-
-
-@inline function next(u::SDMSemiTokenIteration, state::SAIterationState)
-    dt, t, ni = nexthelper(u, state)
-    (IntSemiToken(t), dt.k, dt.d), ni
-end
-
-
-@inline function next(u::SSSemiTokenIteration, state::SAIterationState)
-    dt, t, ni = nexthelper(u, state)
-    (IntSemiToken(t), dt.k), ni
-end
-
-@inline function next(u::SDMSemiTokenKeyIteration, state::SAIterationState)
-    dt, t, ni = nexthelper(u, state)
-    (IntSemiToken(t), dt.k), ni
-end
-
-
-@inline function next(u::SDMSemiTokenValIteration, state::SAIterationState)
-    dt, t, ni = nexthelper(u, state)
-    (IntSemiToken(t), dt.d), ni
-end
-
+start(m::SAContainer) = start(element_it(m))
+next(m::SAContainer, state) = next(element_it(m), state)
+done(m::SAContainer, state) = done(element_it(m), state)
+
+keys(m::SAContainer) = imap(st->st.tree.data[st.idx].k, Leaves(m.bt))
+values(m::SAContainer) = imap(st->st.tree.data[st.idx].d, Leaves(m.bt))
+
+onlysemitokens(m::SAContainer) = imap(st->IntSemiToken(st.idx), Leaves(m.bt))
+
+exclusive(m::SAContainer, start, stop) = element_it(m,
+    RangeIterator(Leaves.m.bt,Subtree(m.bt,start,m.bt.depth),
+        Subtree(m.bt,stop,m.bt.depth)))
+exclusive(m::SAContainer, ii::Tuple) = exclusive(m, ii...)
+inclusive(m::SAContainer, start, stop) = element_it(m,
+    RangeIterator(Leaves.m.bt,Subtree(m.bt,start,m.bt.depth),
+        get(next(Leaves(m.bt),Subtree(m.bt,stop,m.bt.depth))[2])))
+inclusive(m::SAContainer, ii::Tuple) = inclusive(m, ii...)
 
 eachindex(sd::SortedDict) = keys(sd)
 eachindex(sdm::SortedMultiDict) = onlysemitokens(sdm)
 eachindex(ss::SortedSet) = onlysemitokens(ss)
-eachindex{K,D,Ord <: Ordering}(sd::SDMExcludeLast{SortedDict{K,D,Ord}}) = keys(sd)
-eachindex{K,D,Ord <: Ordering}(smd::SDMExcludeLast{SortedMultiDict{K,D,Ord}}) =
-     onlysemitokens(smd)
-eachindex(ss::SSExcludeLast) = onlysemitokens(ss)
-eachindex{K,D,Ord <: Ordering}(sd::SDMIncludeLast{SortedDict{K,D,Ord}}) = keys(sd)
-eachindex{K,D,Ord <: Ordering}(smd::SDMIncludeLast{SortedMultiDict{K,D,Ord}}) =
-     onlysemitokens(smd)
-eachindex(ss::SSIncludeLast) = onlysemitokens(ss)
-
 
 empty!(m::SAContainer) =  empty!(m.bt)
-@inline length(m::SAContainer) = length(m.bt.data) - length(m.bt.freedatainds) - 2
-@inline isempty(m::SAContainer) = length(m) == 0
+length(m::SAContainer) = length(m.bt.data) - length(m.bt.freedatainds)
+isempty(m::SAContainer) = length(m) == 0

--- a/src/tokens2.jl
+++ b/src/tokens2.jl
@@ -182,6 +182,5 @@ end
      i[2].address == 2) && throw(BoundsError())
 
 
-@inline has_data(i::Token) =
-    (!(i[2].address in i[1].bt.useddatacells) ||
-     i[2].address < 3) && throw(BoundsError())
+@inline has_data(i::Token) = !(i[2].address in i[1].bt.useddatacells) &&
+    throw(BoundsError())


### PR DESCRIPTION
This is a WIP to refactor sorted containers.

Currently, this only refactors the 2-3 tree to make use of relevant abstractions in AbstractTrees.jl and Iterators.jl, to express the algorithms at a higher level, making the code quite a bit shorter and hopefully easier to understand. I have done some basic testing, but there's quite a bit more left to do. I've also not done performance tuning yet, so this is likely significantly slower than the previous version. However, I've written the code in a manner that I'm confident I will be able to fully recover the performance without having to give up clarity.

Other potential things I've been thinking about:
 - Get rid of semi tokens from the exported user interface and only use tokens. I believe in most cases the compiler should be able to do any required optimization to remove the redundant information, and if not that's just a missing compiler optimization as opposed to a reason for complicating the API.
- Add a getindex method to SortedMultiDict that returns an iterator over all keys of that values, including the ability to binary search by insertion order (some similarity perhaps to 206).

cc @StephenVavasis @kmsquire (probably not quite ready for thorough review yet, but in case you want an early look).
