### PR TITLE
Add a Deque based on a circular buffer

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.4
+Compat 0.8.5

--- a/doc/source/circ_deque.rst
+++ b/doc/source/circ_deque.rst
@@ -1,0 +1,24 @@
+.. _ref-circ-deque:
+
+-------------
+CircularDeque
+-------------
+
+The ``CircularDeque`` type implements a double-ended queue using a circular buffer of fixed ``capacity``. This data structure supports constant-time insertion/removal of elements at both ends of a sequence.
+
+Usage::
+
+  a = CircularDeque{Int}(n)   # allocate a deque with maximum capacity n
+  isempty(a)          # test whether the deque is empty
+  length(a)           # get the number of elements currently in the deque
+  push!(a, 10)        # add an element to the back
+  pop!(a)             # remove an element from the back
+  unshift!(a, 20)     # add an element to the front
+  shift!(a)           # remove an element from the front
+  front(a)            # get the element at the front
+  back(a)             # get the element at the back
+
+*Note:* Julia's ``Vector`` type also provides this interface, and thus can be used as a deque. However, the ``CircularDeque`` type in this package is implemented as a circular buffer, and thus avoids copying elements when modifications are made to the front of the vector.
+
+Benchmarks show that the performance of ``CircularDeque`` is several
+times faster than ``Deque``.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -4,6 +4,7 @@ DataStructures.jl
 This package implements a variety of data structures, including
 
 * Deque (based on block-list)
+* CircularDeque (based on a circular buffer)
 * Stack
 * Queue
 * Accumulators and Counters
@@ -23,6 +24,7 @@ Contents:
    :maxdepth: 2
 
    deque.rst
+   circ_deque.rst
    stack_and_queue.rst
    accumulators.rst
    disjoint_sets.rst

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -2,6 +2,8 @@ __precompile__()
 
 module DataStructures
 
+    using Compat
+
     import Base: <, <=, ==, length, isempty, start, next, done,
                  show, dump, empty!, getindex, setindex!, get, get!,
                  in, haskey, keys, merge, copy, cat,
@@ -17,7 +19,7 @@ module DataStructures
                  find, searchsortedfirst, searchsortedlast, endof, in
 
 
-    export Deque, Stack, Queue
+    export Deque, Stack, Queue, CircularDeque
     export deque, enqueue!, dequeue!, update!, reverse_iter
     export capacity, num_blocks, front, back, top, sizehint!
 
@@ -56,6 +58,7 @@ module DataStructures
     include("delegate.jl")
 
     include("deque.jl")
+    include("circ_deque.jl")
     include("stack.jl")
     include("queue.jl")
     include("accumulator.jl")

--- a/src/circ_deque.jl
+++ b/src/circ_deque.jl
@@ -1,0 +1,90 @@
+"""
+    CircularDeque{T}(n)
+
+Create a double-ended queue of maximum capacity `n`, implemented as a circular buffer. The element type is `T`.
+"""
+type CircularDeque{T}
+    buffer::Vector{T}
+    capacity::Int
+    n::Int
+    first::Int
+    last::Int
+end
+
+@compat (::Type{CircularDeque{T}}){T}(n::Int) = CircularDeque(Array{T}(n), n, 0, 1, n)
+
+Base.length(D::CircularDeque) = D.n
+Base.eltype{T}(::Type{CircularDeque{T}}) = T
+capacity(D::CircularDeque) = D.capacity
+
+function Base.empty!(D::CircularDeque)
+    D.n = 0
+    D.first = 1
+    D.last = D.capacity
+    D
+end
+
+Base.isempty(D::CircularDeque) = D.n == 0
+
+@inline function front(D::CircularDeque)
+    @compat @boundscheck D.n > 0 || throw(BoundsError())
+    D.buffer[D.first]
+end
+
+@inline function back(D::CircularDeque)
+    @compat @boundscheck D.n > 0 || throw(BoundsError())
+    D.buffer[D.last]
+end
+
+@inline function Base.push!(D::CircularDeque, v)
+    @compat @boundscheck D.n < D.capacity || throw(BoundsError()) # prevent overflow
+    D.n += 1
+    tmp = D.last+1
+    D.last = ifelse(tmp > D.capacity, 1, tmp)  # wraparound
+    @inbounds D.buffer[D.last] = v
+    D
+end
+
+@inline function Base.pop!(D::CircularDeque)
+    v = back(D)
+    D.n -= 1
+    tmp = D.last - 1
+    D.last = ifelse(tmp < 1, D.capacity, tmp)
+    v
+end
+
+@inline function Base.unshift!(D::CircularDeque, v)
+    @compat @boundscheck D.n < D.capacity || throw(BoundsError())
+    D.n += 1
+    tmp = D.first - 1
+    D.first = ifelse(tmp < 1, D.capacity, tmp)
+    @inbounds D.buffer[D.first] = v
+    D
+end
+
+@inline function Base.shift!(D::CircularDeque)
+    v = front(D)
+    D.n -= 1
+    tmp = D.first + 1
+    D.first = ifelse(tmp > D.capacity, 1, tmp)
+    v
+end
+
+@inline function Base.getindex(D::CircularDeque, i::Integer)
+    @compat @boundscheck 1 <= i <= D.n || throw(BoundsError())
+    j = D.first + i - 1
+    if j > D.capacity
+        j -= D.capacity
+    end
+    @inbounds ret = D.buffer[j]
+    ret
+end
+
+function Base.show{T}(io::IO, D::CircularDeque{T})
+    print(io, "CircularDeque{$T}([")
+    for i = 1:length(D)
+        print(io, D[i])
+        i < length(D) && print(io, ',')
+    end
+    print(io, "])")
+end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,2 @@
-Compat 0.7.16
+BaseTestNext
 Primes 0.1.1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,9 @@
-using Base.Test
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 using DataStructures
 const IntSet = DataStructures.IntSet
 import Compat: String
@@ -6,6 +11,7 @@ using Primes
 
 tests = ["int_set",
          "deque",
+         "circ_deque",
          "sorted_containers",
          "stack_and_queue",
          "accumulator",

--- a/test/test_circ_deque.jl
+++ b/test/test_circ_deque.jl
@@ -1,0 +1,82 @@
+using DataStructures
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
+
+@testset "CircularDeque" begin
+    D = CircularDeque{Int}(5)
+    @test eltype(D) == Int
+    @test capacity(D) == 5
+    @test length(D) == 0
+    @test isempty(D)
+    @test_throws BoundsError front(D)
+    @test_throws BoundsError back(D)
+    push!(D, 1)
+    @test front(D) === back(D) === 1
+    push!(D, 2)
+    @test front(D) === 1
+    @test back(D)  === 2
+    @test length(D) == 2
+    for i = 3:5
+        push!(D, i)
+    end
+    @test_throws BoundsError push!(D, 6)
+    @test shift!(D) === 1
+    @test front(D) === 2
+    @test back(D) === 5
+    io = IOBuffer()
+    print(io, Int)
+    intstr = takebuf_string(io)
+    print(io, D)
+    @test takebuf_string(io) == "CircularDeque{$intstr}([2,3,4,5])"
+    push!(D, 6)
+    @test front(D) === 2
+    @test back(D) === 6
+    @test pop!(D) === 6
+    @test front(D) === 2
+    @test back(D) === 5
+    unshift!(D, 7)
+    @test front(D) === 7
+    @test back(D) === 5
+    @test_throws BoundsError unshift!(D, 8)
+    @test shift!(D) === 7
+    @test shift!(D) === 2
+    @test pop!(D) === 5
+    @test shift!(D) === 3
+    @test pop!(D) === 4
+    @test_throws BoundsError pop!(D)
+    @test_throws BoundsError shift!(D)
+    @test isempty(D)
+    push!(D, 10)
+    @test !isempty(D)
+    empty!(D)
+    @test isempty(D)
+    @test_throws BoundsError front(D)
+    push!(D, 20)
+    @test front(D) == back(D) == 20
+    empty!(D)
+    for i = 1:5
+        push!(D, i)
+    end
+    @test shift!(D) == 1
+    push!(D, 6)
+    for i = 2:6
+        @test back(D) === 6
+        @test D[1] === i
+        @test D[7-i] === 6
+        @test shift!(D) === i
+    end
+
+    # Test that unshift! works on an empty deque, and that front/back give the right answer
+    D = CircularDeque{Int}(5)
+    unshift!(D, 30)
+    @test front(D) == back(D) == 30
+    empty!(D)
+    unshift!(D, 40)
+    @test front(D) == back(D) == 40
+end
+
+nothing

--- a/test/test_circular_buffer.jl
+++ b/test/test_circular_buffer.jl
@@ -1,6 +1,10 @@
 using DataStructures
-using Base.Test
-
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 
 cb = CircularBuffer{Int}(5)
 @test length(cb) == 0

--- a/test/test_classified_collections.jl
+++ b/test/test_classified_collections.jl
@@ -1,7 +1,12 @@
 # Test classified collections
 
 using DataStructures
-using Base.Test
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 
 # classified lists
 

--- a/test/test_deque.jl
+++ b/test/test_deque.jl
@@ -1,6 +1,10 @@
 using DataStructures
-using Base.Test
-
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 
 # empty dequeue
 

--- a/test/test_ordered_set.jl
+++ b/test/test_ordered_set.jl
@@ -1,5 +1,10 @@
 using DataStructures
-using Base.Test
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 
 # construction
 


### PR DESCRIPTION
The main attraction of `CircularDeque` is its performance:
```julia
julia> using DataStructures, BenchmarkTools

julia> D = Deque{Int}()
Deque [Int64[]]

julia> C = CircularDeque{Int}(5)
CircularDeque{Int64}([])

julia> function foo!(D)
           for i = 1:5
               push!(D, i)
           end
           v = back(D)
           for i = 1:5
               shift!(D)
           end
           v
       end
foo! (generic function with 1 method)

julia> foo!(D)
5

julia> foo!(C)
5

julia> @benchmark foo!($D)
BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     870
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  0.00 bytes
  allocs estimate:  0
  minimum time:     153.00 ns (0.00% GC)
  median time:      155.00 ns (0.00% GC)
  mean time:        156.19 ns (0.00% GC)
  maximum time:     265.00 ns (0.00% GC)

julia> @benchmark foo!($C)
BenchmarkTools.Trial: 
  samples:          10000
  evals/sample:     995
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  0.00 bytes
  allocs estimate:  0
  minimum time:     30.00 ns (0.00% GC)
  median time:      33.00 ns (0.00% GC)
  mean time:        33.22 ns (0.00% GC)
  maximum time:     56.00 ns (0.00% GC)
```
