### PR TITLE
Faster creation of OrderedDict, revisited

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.4
+julia 0.5-

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.4
-Compat 0.8.5
+Compat 0.9.4

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
-julia 0.5-
+julia 0.4
+Compat 0.8.5

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -2,6 +2,8 @@ __precompile__()
 
 module DataStructures
 
+    using Compat
+
     import Base: <, <=, ==, length, isempty, start, next, done,
                  show, dump, empty!, getindex, setindex!, get, get!,
                  in, haskey, keys, merge, copy, cat,

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -2,14 +2,18 @@
 # OrderedDict
 
 import Base: haskey, get, get!, getkey, delete!, push!, pop!, empty!,
-             setindex!, getindex, length, isempty, start,
-             next, done, keys, values, setdiff, setdiff!,
-             union, union!, intersect, filter, filter!,
-             hash, eltype, KeyIterator, ValueIterator, convert, copy,
-             merge, HasLength, HasShape, SizeUnknown, iteratorsize
+setindex!, getindex, length, isempty, start,
+next, done, keys, values, setdiff, setdiff!,
+union, union!, intersect, filter, filter!,
+hash, eltype, KeyIterator, ValueIterator, convert, copy,
+merge
+
+if VERSION >= v"0.5.0"
+    import Base: HasLength, HasShape, SizeUnknown, iteratorsize
+end
 
 """
-    OrderedDict
+OrderedDict
 
 `OrderedDict`s are  simply dictionaries  whose entries  have a  particular order.  The order
 refers to insertion order, which allows deterministic iteration over the dictionary or set.
@@ -24,21 +28,35 @@ type OrderedDict{K,V} <: Associative{K,V}
     function OrderedDict()
         new(zeros(Int32,16), Array(K,0), Array(V,0), 0, false)
     end
-    function OrderedDict(kv, isz::Union{HasLength, HasShape})
-        n = length(kv)
-        slotsz = max(16, (n*3)>>1 )
-        h = new(zeros(Int32,slotsz), Array(K,n), Array(V,n), 0, false)
-        i = 0
-        for (k,v) in kv
-            i = i + 1
-            index = hashindex(k,slotsz)
-            h.keys[i] = k
-            h.vals[i] = v
-            h.slots[index] = i
+
+    if VERSION >= v"0.5.0"
+        function OrderedDict(kv, isz::Union{HasLength, HasShape})
+            n = length(kv)
+            slotsz = max(16, (n*3)>>1 )
+            h = new(zeros(Int32,slotsz), Array(K,n), Array(V,n), 0, false)
+            i = 0
+            for (k,v) in kv
+                i = i + 1
+                index = hashindex(k,slotsz)
+                h.keys[i] = k
+                h.vals[i] = v
+                h.slots[index] = i
+            end
+            return h
         end
-        return h
+        OrderedDict(kv, isz::SizeUnknown) = OrderedDict{K,V}(kv)
+    else
+        OrderedDict(p::Pair) = setindex!(OrderedDict{K, V}(), p.second, p.first)
+        function OrderedDict(ps::Pair...)
+            h = OrderedDict{K, V}()
+            sizehint!(h, length(ps))
+            for p in ps
+                h[p.first] = p.second
+            end
+            return h
+        end
     end
-    OrderedDict(kv, isz::SizeUnknown) = OrderedDict{K,V}(kv)
+    
     function OrderedDict(kv)
         h = OrderedDict{K,V}()
         for (k,v) in kv
@@ -58,24 +76,40 @@ OrderedDict() = OrderedDict{Any,Any}()
 OrderedDict(kv::Tuple{}) = OrderedDict()
 copy(d::OrderedDict) = OrderedDict(d)
 
-
 # TODO: this can probably be simplified using `eltype` as a THT (Tim Holy trait)
 # OrderedDict{K,V}(kv::Tuple{Vararg{Tuple{K,V}}})          = OrderedDict{K,V}(kv)
 # OrderedDict{K  }(kv::Tuple{Vararg{Tuple{K,Any}}})        = OrderedDict{K,Any}(kv)
 # OrderedDict{V  }(kv::Tuple{Vararg{Tuple{Any,V}}})        = OrderedDict{Any,V}(kv)
-OrderedDict{K,V}(kv::Tuple{Vararg{Pair{K,V}}})         = OrderedDict{K,V}(kv, iteratorsize(kv))
-OrderedDict{K}(kv::Tuple{Vararg{Pair{K}}})             = OrderedDict{K,Any}(kv, iteratorsize(kv))
-OrderedDict{V}(kv::Tuple{Vararg{Pair{TypeVar(:K),V}}}) = OrderedDict{Any,V}(kv, iteratorsize(kv))
-OrderedDict(kv::Tuple{Vararg{Pair}})                   = OrderedDict{Any,Any}(kv, iteratorsize(kv))
 
-OrderedDict{K,V}(kv::AbstractArray{Tuple{K,V}}) = OrderedDict{K,V}(kv, iteratorsize(kv))
-OrderedDict{K,V}(kv::AbstractArray{Pair{K,V}})  = OrderedDict{K,V}(kv, iteratorsize(kv))
-OrderedDict{K,V}(kv::Associative{K,V})          = OrderedDict{K,V}(kv, iteratorsize(kv))
+if VERSION >= v"0.5.0"
+    OrderedDict{K,V}(kv::Tuple{Vararg{Pair{K,V}}})         = OrderedDict{K,V}(kv, iteratorsize(kv))
+    OrderedDict{K}(kv::Tuple{Vararg{Pair{K}}})             = OrderedDict{K,Any}(kv, iteratorsize(kv))
+    OrderedDict{V}(kv::Tuple{Vararg{Pair{TypeVar(:K),V}}}) = OrderedDict{Any,V}(kv, iteratorsize(kv))
+    OrderedDict(kv::Tuple{Vararg{Pair}})                   = OrderedDict{Any,Any}(kv, iteratorsize(kv))
 
-OrderedDict{K,V}(ps::Pair{K,V}...)          = OrderedDict{K,V}(ps, iteratorsize(ps))
-OrderedDict{K}(ps::Pair{K}...,)             = OrderedDict{K,Any}(ps, iteratorsize(ps))
-OrderedDict{V}(ps::Pair{TypeVar(:K),V}...,) = OrderedDict{Any,V}(ps, iteratorsize(ps))
-OrderedDict(ps::Pair...)                    = OrderedDict{Any,Any}(ps, iteratorsize(ps))
+    OrderedDict{K,V}(kv::AbstractArray{Tuple{K,V}}) = OrderedDict{K,V}(kv, iteratorsize(kv))
+    OrderedDict{K,V}(kv::AbstractArray{Pair{K,V}})  = OrderedDict{K,V}(kv, iteratorsize(kv))
+    OrderedDict{K,V}(kv::Associative{K,V})          = OrderedDict{K,V}(kv, iteratorsize(kv))
+
+    OrderedDict{K,V}(ps::Pair{K,V}...)          = OrderedDict{K,V}(ps, iteratorsize(ps))
+    OrderedDict{K}(ps::Pair{K}...,)             = OrderedDict{K,Any}(ps, iteratorsize(ps))
+    OrderedDict{V}(ps::Pair{TypeVar(:K),V}...,) = OrderedDict{Any,V}(ps, iteratorsize(ps))
+    OrderedDict(ps::Pair...)                    = OrderedDict{Any,Any}(ps, iteratorsize(ps))
+else
+    OrderedDict{K, V}(kv::Tuple{Vararg{Pair{K, V}}})         = OrderedDict{K, V}(kv)
+    OrderedDict{K}(kv::Tuple{Vararg{Pair{K}}})               = OrderedDict{K, Any}(kv)
+    OrderedDict{V}(kv::Tuple{Vararg{Pair{TypeVar(:K), V}}})  = OrderedDict{Any, V}(kv)
+    OrderedDict(kv::Tuple{Vararg{Pair}})                     = OrderedDict{Any, Any}(kv)
+
+    OrderedDict{K, V}(kv::AbstractArray{Tuple{K, V}}) = OrderedDict{K, V}(kv)
+    OrderedDict{K, V}(kv::AbstractArray{Pair{K, V}})  = OrderedDict{K, V}(kv)
+    OrderedDict{K, V}(kv::Associative{K, V})          = OrderedDict{K, V}(kv)
+
+    OrderedDict{K, V}(ps::Pair{K, V}...)          = OrderedDict{K, V}(ps)
+    OrderedDict{K}(ps::Pair{K}..., )              = OrderedDict{K, Any}(ps)
+    OrderedDict{V}(ps::Pair{TypeVar(:K), V}..., ) = OrderedDict{Any, V}(ps)
+    OrderedDict(ps::Pair...)                      = OrderedDict{Any, Any}(ps)
+end
 
 function OrderedDict(kv)
     try
@@ -90,9 +124,15 @@ function OrderedDict(kv)
     end
 end
 
-dict_with_eltype{K,V}(kv, ::Type{Tuple{K,V}}) = OrderedDict{K,V}(kv, iteratorsize(kv))
-dict_with_eltype{K,V}(kv, ::Type{Pair{K,V}}) = OrderedDict{K,V}(kv, iteratorsize(kv))
-dict_with_eltype(kv, t) = OrderedDict{Any,Any}(kv, iteratorsize(kv))
+if VERSION >= v"0.5.0"
+    dict_with_eltype{K,V}(kv, ::Type{Tuple{K,V}}) = OrderedDict{K,V}(kv, iteratorsize(kv))
+    dict_with_eltype{K,V}(kv, ::Type{Pair{K,V}}) = OrderedDict{K,V}(kv, iteratorsize(kv))
+    dict_with_eltype(kv, t) = OrderedDict{Any,Any}(kv, iteratorsize(kv))
+else
+    dict_with_eltype{K, V}(kv,  ::Type{Tuple{K, V}}) = OrderedDict{K, V}(kv)
+    dict_with_eltype{K, V}(kv,  ::Type{Pair{K, V}}) = OrderedDict{K, V}(kv)
+    dict_with_eltype(kv,  t) = OrderedDict{Any, Any}(kv)
+end
 
 similar{K,V}(d::OrderedDict{K,V}) = OrderedDict{K,V}()
 
@@ -298,7 +338,7 @@ function setindex!{K,V}(h::OrderedDict{K,V}, v0, key0)
     if !isequal(key,key0)
         throw(ArgumentError("$key0 is not a valid key for type $K"))
     end
-    v = convert(V,  v0)
+    v = convert(V, v0)
 
     index = ht_keyindex2(h, key)
 
@@ -322,7 +362,7 @@ function get!{K,V}(h::OrderedDict{K,V}, key0, default)
 
     index > 0 && return h.vals[index]
 
-    v = convert(V,  default)
+    v = convert(V, default)
     _setindex!(h, v, key, -index)
     return v
 end
@@ -338,7 +378,7 @@ function get!{K,V}(default::Base.Callable, h::OrderedDict{K,V}, key0)
     index > 0 && return h.vals[index]
 
     h.dirty = false
-    v = convert(V,  default())
+    v = convert(V, default())
     if h.dirty
         index = ht_keyindex2(h, key)
     end

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -2,11 +2,11 @@
 # OrderedDict
 
 import Base: haskey, get, get!, getkey, delete!, push!, pop!, empty!,
-setindex!, getindex, length, isempty, start,
-next, done, keys, values, setdiff, setdiff!,
-union, union!, intersect, filter, filter!,
-hash, eltype, KeyIterator, ValueIterator, convert, copy,
-merge
+             setindex!, getindex, length, isempty, start,
+             next, done, keys, values, setdiff, setdiff!,
+             union, union!, intersect, filter, filter!,
+             hash, eltype, KeyIterator, ValueIterator, convert, copy,
+             merge
 
 if VERSION >= v"0.5.0"
     import Base: HasLength, HasShape, SizeUnknown, iteratorsize
@@ -100,26 +100,26 @@ end
 
     dict_with_eltype{K,V}(kv, ::Type{Tuple{K,V}}) = OrderedDict{K,V}(kv, iteratorsize(kv))
     dict_with_eltype{K,V}(kv, ::Type{Pair{K,V}}) = OrderedDict{K,V}(kv, iteratorsize(kv))
-    dict_with_eltype(kv, t) = OrderedDict{Any,Any}(kv, iteratorsize(kv))
+    dict_with_eltype(kv,t) = OrderedDict{Any,Any}(kv, iteratorsize(kv))
 
 else
-    OrderedDict{K, V}(kv::Tuple{Vararg{Pair{K, V}}})         = OrderedDict{K, V}(kv)
+    OrderedDict{K,V}(kv::Tuple{Vararg{Pair{K, V}}})         = OrderedDict{K, V}(kv)
     OrderedDict{K}(kv::Tuple{Vararg{Pair{K}}})               = OrderedDict{K, Any}(kv)
     OrderedDict{V}(kv::Tuple{Vararg{Pair{TypeVar(:K), V}}})  = OrderedDict{Any, V}(kv)
     OrderedDict(kv::Tuple{Vararg{Pair}})                     = OrderedDict{Any, Any}(kv)
 
-    OrderedDict{K, V}(kv::AbstractArray{Tuple{K, V}}) = OrderedDict{K, V}(kv)
-    OrderedDict{K, V}(kv::AbstractArray{Pair{K, V}})  = OrderedDict{K, V}(kv)
-    OrderedDict{K, V}(kv::Associative{K, V})          = OrderedDict{K, V}(kv)
+    OrderedDict{K,V}(kv::AbstractArray{Tuple{K, V}}) = OrderedDict{K, V}(kv)
+    OrderedDict{K,V}(kv::AbstractArray{Pair{K, V}})  = OrderedDict{K, V}(kv)
+    OrderedDict{K,V}(kv::Associative{K, V})          = OrderedDict{K, V}(kv)
 
-    OrderedDict{K, V}(ps::Pair{K, V}...)          = OrderedDict{K, V}(ps)
+    OrderedDict{K,V}(ps::Pair{K, V}...)          = OrderedDict{K, V}(ps)
     OrderedDict{K}(ps::Pair{K}..., )              = OrderedDict{K, Any}(ps)
     OrderedDict{V}(ps::Pair{TypeVar(:K), V}..., ) = OrderedDict{Any, V}(ps)
     OrderedDict(ps::Pair...)                      = OrderedDict{Any, Any}(ps)
 
-    dict_with_eltype{K, V}(kv,  ::Type{Tuple{K, V}}) = OrderedDict{K, V}(kv)
-    dict_with_eltype{K, V}(kv,  ::Type{Pair{K, V}}) = OrderedDict{K, V}(kv)
-    dict_with_eltype(kv,  t) = OrderedDict{Any, Any}(kv)
+    dict_with_eltype{K,V}(kv,  ::Type{Tuple{K, V}}) = OrderedDict{K, V}(kv)
+    dict_with_eltype{K,V}(kv,  ::Type{Pair{K, V}}) = OrderedDict{K, V}(kv)
+    dict_with_eltype(kv,t) = OrderedDict{Any, Any}(kv)
 end
 
 similar{K,V}(d::OrderedDict{K,V}) = OrderedDict{K,V}()

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -53,7 +53,7 @@ type OrderedDict{K,V} <: Associative{K,V}
         end
         return h
     end
-    
+
     function OrderedDict(d::OrderedDict{K,V})
         if d.ndel > 0
             rehash!(d)

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -33,11 +33,16 @@ type OrderedDict{K,V} <: Associative{K,V}
         if n > 0
             i = 0
             for (k,v) in kv
-                i = i + 1
                 index = ht_keyindex2(h, k)
-                @inbounds h.keys[i] = k
-                @inbounds h.vals[i] = v
-                @inbounds h.slots[-index] = i
+                if index < 0 # new key
+                    i = i + 1
+                    @inbounds h.keys[i] = k
+                    @inbounds h.vals[i] = v
+                    @inbounds h.slots[-index] = i
+                else # duplicate key, shrink by one
+                    @inbounds h.vals[index] = v
+                    h.ndel = h.ndel + 1
+                end
             end
         else # Unknown length
             for (k,v) in kv

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -41,7 +41,9 @@ type OrderedDict{K,V} <: Associative{K,V}
                     @inbounds h.slots[-index] = i
                 else # duplicate key, shrink by one
                     @inbounds h.vals[index] = v
-                    h.ndel = h.ndel + 1
+                    n = n - 1
+                    resize!(h.keys, n)
+                    resize!(h.vals, n)
                 end
             end
         else # Unknown length

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -15,7 +15,7 @@ end
 """
 OrderedDict
 
-`OrderedDict`s are  simply dictionaries  whose entries  have a  particular order.  The order
+`OrderedDict`s are simply dictionaries whose entries have a particular order.  The order
 refers to insertion order, which allows deterministic iteration over the dictionary or set.
 """
 type OrderedDict{K,V} <: Associative{K,V}

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -30,14 +30,20 @@ type OrderedDict{K,V} <: Associative{K,V}
     function OrderedDict(kv)
         (n, slotsz) = get_n_slotsz(kv)
         h = new(zeros(Int32,slotsz), Array(K,n), Array(V,n), 0, false)
-        i = 0
-        for (k,v) in kv
-            i = i + 1
-            index = ht_keyindex2(h, k)
-            @inbounds h.keys[i] = k
-            @inbounds h.vals[i] = v
-            @inbounds h.slots[-index] = i
+        if n > 0
+            i = 0
+            for (k,v) in kv
+                i = i + 1
+                index = ht_keyindex2(h, k)
+                @inbounds h.keys[i] = k
+                @inbounds h.vals[i] = v
+                @inbounds h.slots[-index] = i
             end
+        else # Unknown length
+            for (k,v) in kv
+                h[k] = v
+            end
+        end
         return h
     end
     
@@ -71,7 +77,7 @@ function OrderedDict(kv)
     end
 end
 
-@static if VERSION >= v"0.5.0"
+if VERSION >= v"0.5.0"
     get_n_slotsz(kv) = get_n_slotsz(kv, iteratorsize(kv))
     get_n_slotsz(kv, isz::SizeUnknown) = (0, 16)
     function get_n_slotsz(kv, isz::Union{HasLength, HasShape})

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -44,22 +44,6 @@ type OrderedDict{K,V} <: Associative{K,V}
         end
         OrderedDict(kv, isz::SizeUnknown) = OrderedDict{K,V}(kv)
     end
-
-    OrderedDict(p::Pair) = setindex!(OrderedDict{K, V}(), p.second, p.first)
-    function OrderedDict(ps::Pair...)
-        n = length(kv)
-        slotsz = max(16, (n*3)>>1 )
-        h = new(zeros(Int32,slotsz), Array(K,n), Array(V,n), 0, false)
-        i = 0
-        for p in ps
-            i = i + 1
-            index = hashindex(k,slotsz)
-            h.keys[i] = p.first
-            h.vals[i] = p.second
-            h.slots[index] = i
-        end
-        return h
-    end
     
     function OrderedDict(kv)
         h = OrderedDict{K,V}()

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -77,7 +77,7 @@ function OrderedDict(kv)
     end
 end
 
-if VERSION >= v"0.5.0"
+@static if VERSION >= v"0.5.0"
     get_n_slotsz(kv) = get_n_slotsz(kv, iteratorsize(kv))
     get_n_slotsz(kv, isz::SizeUnknown) = (0, 16)
     function get_n_slotsz(kv, isz::Union{HasLength, HasShape})

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -34,9 +34,9 @@ type OrderedDict{K,V} <: Associative{K,V}
         for (k,v) in kv
             i = i + 1
             index = hashindex(k,slotsz)
-            h.keys[i] = k
-            h.vals[i] = v
-            h.slots[index] = i
+            @inbounds h.keys[i] = k
+            @inbounds h.vals[i] = v
+            @inbounds h.slots[index] = i
             end
         return h
     end

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -6,7 +6,7 @@ import Base: haskey, get, get!, getkey, delete!, push!, pop!, empty!,
              next, done, keys, values, setdiff, setdiff!,
              union, union!, intersect, filter, filter!,
              hash, eltype, KeyIterator, ValueIterator, convert, copy,
-             merge
+             merge, HasLength, HasShape, SizeUnknown, iteratorsize
 
 """
     OrderedDict
@@ -24,19 +24,25 @@ type OrderedDict{K,V} <: Associative{K,V}
     function OrderedDict()
         new(zeros(Int32,16), Array(K,0), Array(V,0), 0, false)
     end
+    function OrderedDict(kv, isz::Union{HasLength, HasShape})
+        n = length(kv)
+        slotsz = max(16, (n*3)>>1 )
+        h = new(zeros(Int32,slotsz), Array(K,n), Array(V,n), 0, false)
+        i = 0
+        for (k,v) in kv
+            i = i + 1
+            index = hashindex(k,slotsz)
+            h.keys[i] = k
+            h.vals[i] = v
+            h.slots[index] = i
+        end
+        return h
+    end
+    OrderedDict(kv, isz::SizeUnknown) = OrderedDict{K,V}(kv)
     function OrderedDict(kv)
         h = OrderedDict{K,V}()
         for (k,v) in kv
             h[k] = v
-        end
-        return h
-    end
-    OrderedDict(p::Pair) = setindex!(OrderedDict{K,V}(), p.second, p.first)
-    function OrderedDict(ps::Pair...)
-        h = OrderedDict{K,V}()
-        sizehint!(h, length(ps))
-        for p in ps
-            h[p.first] = p.second
         end
         return h
     end
@@ -57,19 +63,19 @@ copy(d::OrderedDict) = OrderedDict(d)
 # OrderedDict{K,V}(kv::Tuple{Vararg{Tuple{K,V}}})          = OrderedDict{K,V}(kv)
 # OrderedDict{K  }(kv::Tuple{Vararg{Tuple{K,Any}}})        = OrderedDict{K,Any}(kv)
 # OrderedDict{V  }(kv::Tuple{Vararg{Tuple{Any,V}}})        = OrderedDict{Any,V}(kv)
-OrderedDict{K,V}(kv::Tuple{Vararg{Pair{K,V}}})         = OrderedDict{K,V}(kv)
-OrderedDict{K}(kv::Tuple{Vararg{Pair{K}}})             = OrderedDict{K,Any}(kv)
-OrderedDict{V}(kv::Tuple{Vararg{Pair{TypeVar(:K),V}}}) = OrderedDict{Any,V}(kv)
-OrderedDict(kv::Tuple{Vararg{Pair}})                   = OrderedDict{Any,Any}(kv)
+OrderedDict{K,V}(kv::Tuple{Vararg{Pair{K,V}}})         = OrderedDict{K,V}(kv, iteratorsize(kv))
+OrderedDict{K}(kv::Tuple{Vararg{Pair{K}}})             = OrderedDict{K,Any}(kv, iteratorsize(kv))
+OrderedDict{V}(kv::Tuple{Vararg{Pair{TypeVar(:K),V}}}) = OrderedDict{Any,V}(kv, iteratorsize(kv))
+OrderedDict(kv::Tuple{Vararg{Pair}})                   = OrderedDict{Any,Any}(kv, iteratorsize(kv))
 
-OrderedDict{K,V}(kv::AbstractArray{Tuple{K,V}}) = OrderedDict{K,V}(kv)
-OrderedDict{K,V}(kv::AbstractArray{Pair{K,V}})  = OrderedDict{K,V}(kv)
-OrderedDict{K,V}(kv::Associative{K,V})          = OrderedDict{K,V}(kv)
+OrderedDict{K,V}(kv::AbstractArray{Tuple{K,V}}) = OrderedDict{K,V}(kv, iteratorsize(kv))
+OrderedDict{K,V}(kv::AbstractArray{Pair{K,V}})  = OrderedDict{K,V}(kv, iteratorsize(kv))
+OrderedDict{K,V}(kv::Associative{K,V})          = OrderedDict{K,V}(kv, iteratorsize(kv))
 
-OrderedDict{K,V}(ps::Pair{K,V}...)          = OrderedDict{K,V}(ps)
-OrderedDict{K}(ps::Pair{K}...,)             = OrderedDict{K,Any}(ps)
-OrderedDict{V}(ps::Pair{TypeVar(:K),V}...,) = OrderedDict{Any,V}(ps)
-OrderedDict(ps::Pair...)                    = OrderedDict{Any,Any}(ps)
+OrderedDict{K,V}(ps::Pair{K,V}...)          = OrderedDict{K,V}(ps, iteratorsize(ps))
+OrderedDict{K}(ps::Pair{K}...,)             = OrderedDict{K,Any}(ps, iteratorsize(ps))
+OrderedDict{V}(ps::Pair{TypeVar(:K),V}...,) = OrderedDict{Any,V}(ps, iteratorsize(ps))
+OrderedDict(ps::Pair...)                    = OrderedDict{Any,Any}(ps, iteratorsize(ps))
 
 function OrderedDict(kv)
     try
@@ -84,9 +90,9 @@ function OrderedDict(kv)
     end
 end
 
-dict_with_eltype{K,V}(kv, ::Type{Tuple{K,V}}) = OrderedDict{K,V}(kv)
-dict_with_eltype{K,V}(kv, ::Type{Pair{K,V}}) = OrderedDict{K,V}(kv)
-dict_with_eltype(kv, t) = OrderedDict{Any,Any}(kv)
+dict_with_eltype{K,V}(kv, ::Type{Tuple{K,V}}) = OrderedDict{K,V}(kv, iteratorsize(kv))
+dict_with_eltype{K,V}(kv, ::Type{Pair{K,V}}) = OrderedDict{K,V}(kv, iteratorsize(kv))
+dict_with_eltype(kv, t) = OrderedDict{Any,Any}(kv, iteratorsize(kv))
 
 similar{K,V}(d::OrderedDict{K,V}) = OrderedDict{K,V}()
 

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -33,10 +33,10 @@ type OrderedDict{K,V} <: Associative{K,V}
         i = 0
         for (k,v) in kv
             i = i + 1
-            index = hashindex(k,slotsz)
+            index = ht_keyindex2(h, k)
             @inbounds h.keys[i] = k
             @inbounds h.vals[i] = v
-            @inbounds h.slots[index] = i
+            @inbounds h.slots[-index] = i
             end
         return h
     end

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -3,10 +3,10 @@
 @test isa(OrderedDict(), OrderedDict{Any,Any})
 @test isa(OrderedDict([(1,2.0)]), OrderedDict{Int,Float64})
 @test isa(OrderedDict([("a",1),("b",2)]), OrderedDict{Compat.ASCIIString,Int})
-@test isa(OrderedDict(Pair(1, 1.0)), OrderedDict{Int,Float64})
-@test isa(OrderedDict(Pair(1, 1.0), Pair(2, 2.0)), OrderedDict{Int,Float64})
-@test isa(OrderedDict(Pair(1, 1.0), Pair(2, 2.0), Pair(3, 3.0)), OrderedDict{Int,Float64})
-@test isa(OrderedDict([Pair(1, 1.0), Pair(2, 2.0), Pair(3, 3.0)]), OrderedDict{Int,Float64})
+@test isa(OrderedDict(1 => 1.0), OrderedDict{Int,Float64})
+@test isa(OrderedDict(1 => 1.0, 2 => 2.0), OrderedDict{Int,Float64})
+@test isa(OrderedDict(1 => 1.0, 2 => 2.0, 3 => 3.0), OrderedDict{Int,Float64})
+@test isa(OrderedDict([1 => 1.0, 2 => 2.0, 3 => 3.0]), OrderedDict{Int,Float64})
 
 # empty dictionary
 

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -6,6 +6,7 @@
 @test isa(OrderedDict(Pair(1, 1.0)), OrderedDict{Int,Float64})
 @test isa(OrderedDict(Pair(1, 1.0), Pair(2, 2.0)), OrderedDict{Int,Float64})
 @test isa(OrderedDict(Pair(1, 1.0), Pair(2, 2.0), Pair(3, 3.0)), OrderedDict{Int,Float64})
+@test isa(OrderedDict([Pair(1, 1.0), Pair(2, 2.0), Pair(3, 3.0)]), OrderedDict{Int,Float64})
 
 # empty dictionary
 

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -13,6 +13,15 @@ x = OrderedDict( "a" => 4, "b" => 5, "c" => 6, "b" => 12, "c" => 44 )
 @test x.keys == ["a", "b", "c"]
 @test x.vals == [4, 12, 44]
 
+# test for JuliaLang/julia#15077
+l = 300
+x = [ (string( "foo", i ), i) for i in 1:l ]
+d = OrderedDict(x)
+@test length(d) == l
+for (k,v) in x
+    @test haskey(d,k) == true
+end
+
 # empty dictionary
 
 d = OrderedDict{Char, Int}()

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -8,6 +8,11 @@
 @test isa(OrderedDict(1 => 1.0, 2 => 2.0, 3 => 3.0), OrderedDict{Int,Float64})
 @test isa(OrderedDict([1 => 1.0, 2 => 2.0, 3 => 3.0]), OrderedDict{Int,Float64})
 
+# construction with duplicate keys
+x = OrderedDict( "a" => 4, "b" => 5, "c" => 6, "b" => 12, "c" => 44 )
+@test x.keys == ["a", "b", "c"]
+@test x.vals == [4, 12, 44]
+
 # empty dictionary
 
 d = OrderedDict{Char, Int}()

--- a/test/test_ordered_dict.jl
+++ b/test/test_ordered_dict.jl
@@ -8,6 +8,7 @@
 @test isa(OrderedDict(Pair(1, 1.0), Pair(2, 2.0), Pair(3, 3.0)), OrderedDict{Int,Float64})
 
 # empty dictionary
+
 d = OrderedDict{Char, Int}()
 @test length(d) == 0
 @test isempty(d)
@@ -20,7 +21,7 @@ empty!(d)
 @test isempty(d)
 
 # access, modification
-
+d = OrderedDict{Char, Int}()
 for c in 'a':'z'
     d[c] = c-'a'+1
 end


### PR DESCRIPTION
This PR enables much faster creation of OrderedDict objects in julia 0.5 and is backwards compatible with 0.4.
