### PR TITLE
RFC: Allow sorting on OrderedDicts

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -88,6 +88,8 @@ module DataStructures
     include("tokens2.jl")
     include("container_loops.jl")
 
+    include("dict_sorting.jl")
+
     export
         CircularBuffer,
         capacity,

--- a/src/dict_sorting.jl
+++ b/src/dict_sorting.jl
@@ -1,0 +1,31 @@
+# Sort for dicts
+import Base: sort, sort!
+
+function sort!(d::OrderedDict; byvalue::Bool=false, args...)
+    if d.ndel > 0
+        rehash!(d)
+    end
+
+    if byvalue
+        p = sortperm(d.vals; args...)
+    else
+        p = sortperm(d.keys; args...)
+    end
+
+    for (i,key) in enumerate(d.keys)
+        idx = ht_keyindex(d, key, false)
+        d.slots[idx] = p[i]
+    end
+
+    d.keys = d.keys[p]
+    d.vals = d.vals[p]
+
+    return d
+end
+
+sort(d::OrderedDict; args...) = sort!(copy(d); args...)
+sort(d::Dict; args...) = sort!(OrderedDict(d); args...)
+## Uncomment these after #224 is merged
+# sort!(d::DefaultOrderedDict; args...) = (sort!(d.d.d; args...); d)
+# sort(d::DefaultDict; args...) = DefaultOrderedDict(d.d.default, sort(d.d.d; args...))
+# sort(d::DefaultOrderedDict; args...) = DefaultOrderedDict(d.d.default, sort!(copy(d.d.d); args...))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,8 @@ tests = ["int_set",
          "trie",
          "list",
          "multi_dict",
-         "circular_buffer"]
+         "circular_buffer",
+         "sorting"]
 
 if length(ARGS) > 0
     tests = ARGS

--- a/test/test_sorting.jl
+++ b/test/test_sorting.jl
@@ -1,0 +1,35 @@
+using DataStructures
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
+
+@testset "DictionarySorting" begin
+    forward = OrderedDict(zip('a':'z', 26:-1:1))
+    rev = OrderedDict(zip(reverse('a':'z'), 1:26))
+
+    d = copy(rev)
+    @test d == rev
+    @test sort(d) == forward
+    sort!(d)
+    @test d == forward
+    @test sort(d; rev=true) == rev
+    sort!(d; rev=true)
+    @test d == rev
+    @test sort(d; byvalue=true) == rev
+    @test sort(d; byvalue=true, rev=true) == forward
+    sort!(d; byvalue=true, rev=true)
+    @test d == forward
+    @test sort(d; byvalue=true) == rev
+    @test sort(d; byvalue=true, rev=true) == forward
+    sort!(d; byvalue=true)
+    @test d == rev
+
+    unordered = Dict(zip('a':'z', 26:-1:1))
+    @test sort(unordered) == forward
+    @test sort(unordered; rev=true) == rev
+    @test sort(unordered; byvalue=true) == rev
+    @test sort(unordered; byvalue=true, rev=true) == forward
+end


### PR DESCRIPTION
* Also define `sort(d::Dict)` to yield an `OrderedDict`

Supersedes #43  