### PR TITLE
Make Accumulator an immutable subtype of Associative

### DIFF
--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -1,6 +1,6 @@
 # A counter type
 
-type Accumulator{T, V<:Number}
+immutable Accumulator{T, V<:Number} <: Associative{K,V}
     map::Dict{T,V}
 end
 

--- a/src/accumulator.jl
+++ b/src/accumulator.jl
@@ -1,6 +1,6 @@
 # A counter type
 
-immutable Accumulator{T, V<:Number} <: Associative{K,V}
+immutable Accumulator{T, V<:Number} <: Associative{T,V}
     map::Dict{T,V}
 end
 


### PR DESCRIPTION
Accumulator can be immutable -- the contents of the `map` changes, the `map` never does.
`immutable` should be preferred to `type` where possible, as it is more performant.

And accumulator should be a subtype of Associative -- because it is.
This lets it be used as a dispatch.
