### PR TITLE
RFC: Deprecate or fix old/broken DefaultDict constructors

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -99,6 +99,20 @@ module DataStructures
     export status
     export deref_key, deref_value, deref, advance, regress
 
+    # Deprecations
+
+    # Remove when Julia 0.6 is released
     @deprecate iter(s::Stack) s
     @deprecate iter(q::Queue) q
+
+    # Remove when Julia 0.7 (or whatever version is after v0.6) is released
+    @deprecate DefaultDictBase(default, ks::AbstractArray, vs::AbstractArray) DefaultDictBase(default, zip(ks, vs))
+    @deprecate DefaultDictBase(default, ks, vs) DefaultDictBase(default, zip(ks, vs))
+    @deprecate DefaultDictBase{K,V}(::Type{K}, ::Type{V}, default) DefaultDictBase{K,V}(default)
+
+    @deprecate DefaultDict(default, ks, vs) DefaultDict(default, zip(ks, vs))
+    @deprecate DefaultDict{K,V}(::Type{K}, ::Type{V}, default) DefaultDict{K,V}(default)
+
+    @deprecate DefaultOrderedDict(default, ks, vs) DefaultOrderedDict(default, zip(ks, vs))
+    @deprecate DefaultOrderedDict{K,V}(::Type{K}, ::Type{V}, default) DefaultOrderedDict{K,V}(default)
 end

--- a/src/default_dict.jl
+++ b/src/default_dict.jl
@@ -34,10 +34,10 @@ DefaultDictBase() = throw(ArgumentError("no default specified"))
 DefaultDictBase(k,v) = throw(ArgumentError("no default specified"))
 
 # syntax entry points
-DefaultDictBase{F}(default::F) = DefaultDictBase{Any,Any,F,Dict}(default)
-DefaultDictBase{K,V,F}(default::F, kv::AbstractArray{Tuple{K,V}}) = DefaultDictBase{K,V,F,Dict}(default, kv)
-DefaultDictBase{K,V,F}(default::F, ps::Pair{K,V}...) = DefaultDictBase{K,V,F,Dict}(default, ps...)
-DefaultDictBase{F,D<:Associative}(default::F, d::D) = ((K,V)=eltype(d); DefaultDictBase{K,V,F,D}(default, d))
+DefaultDictBase{F}(default::F) = DefaultDictBase{Any,Any,F,Dict{Any,Any}}(default)
+DefaultDictBase{K,V,F}(default::F, kv::AbstractArray{Tuple{K,V}}) = DefaultDictBase{K,V,F,Dict{K,V}}(default, kv)
+DefaultDictBase{K,V,F}(default::F, ps::Pair{K,V}...) = DefaultDictBase{K,V,F,Dict{K,V}}(default, ps...)
+DefaultDictBase{F,D<:Associative}(default::F, d::D) = (K=keytype(d); V=valtype(d); DefaultDictBase{K,V,F,D}(default, d))
 
 # Constructor for DefaultDictBase{Int,Float64}(0.0)
 @compat (::Type{DefaultDictBase{K,V}}){K,V,F}(default::F) = DefaultDictBase{K,V,F,Dict{K,V}}(default)

--- a/src/default_dict.jl
+++ b/src/default_dict.jl
@@ -26,7 +26,6 @@ immutable DefaultDictBase{K,V,F,D} <: Associative{K,V}
 
     DefaultDictBase(x::F, d::DefaultDictBase) = (check_D(D,K,V); DefaultDictBase(x, d.d))
     DefaultDictBase(x::F, d::D=D()) = (check_D(D,K,V); new(x, d))
-    DefaultDictBase(x, ks, vs) = (check_D(D,K,V); new(x, D(ks,vs)))
 end
 
 # Constructors
@@ -34,17 +33,14 @@ end
 DefaultDictBase() = throw(ArgumentError("no default specified"))
 DefaultDictBase(k,v) = throw(ArgumentError("no default specified"))
 
-# TODO: these mimic similar Dict constructors, but may not be needed
-DefaultDictBase{K,V,F}(default::F, ks::AbstractArray{K}, vs::AbstractArray{V}) =
-    DefaultDictBase{K,V,F,Dict{K,V}}(default,ks,vs)
-DefaultDictBase{F}(default::F,ks,vs) = DefaultDictBase{Any,Any,F,Dict}(default, ks, vs)
-
 # syntax entry points
 DefaultDictBase{F}(default::F) = DefaultDictBase{Any,Any,F,Dict}(default)
-DefaultDictBase{K,V,F}(::Type{K}, ::Type{V}, default::F) = DefaultDictBase{K,V,F,Dict}(default)
 DefaultDictBase{K,V,F}(default::F, kv::AbstractArray{Tuple{K,V}}) = DefaultDictBase{K,V,F,Dict}(default, kv)
 DefaultDictBase{K,V,F}(default::F, ps::Pair{K,V}...) = DefaultDictBase{K,V,F,Dict}(default, ps...)
 DefaultDictBase{F,D<:Associative}(default::F, d::D) = ((K,V)=eltype(d); DefaultDictBase{K,V,F,D}(default, d))
+
+# Constructor for DefaultDictBase{Int,Float64}(0.0)
+@compat (::Type{DefaultDictBase{K,V}}){K,V,F}(default::F) = DefaultDictBase{K,V,F,Dict{K,V}}(default)
 
 # Functions
 
@@ -77,7 +73,6 @@ for (DefaultDict,O) in [(:DefaultDict, :Unordered), (:DefaultOrderedDict, :Order
             $DefaultDict(x, d::$DefaultDict) = $DefaultDict(x, d.d)
             $DefaultDict(x, d::HashDict) = new(DefaultDictBase{K,V,F,HashDict{K,V,$O}}(x, d))
             $DefaultDict(x) = new(DefaultDictBase{K,V,F,HashDict{K,V,$O}}(x))
-            $DefaultDict(x, ks, vs) = new(DefaultDictBase{K,V,F,HashDict{K,V,$O}}(x,ks,vs))
         end
 
         ## Constructors
@@ -85,17 +80,16 @@ for (DefaultDict,O) in [(:DefaultDict, :Unordered), (:DefaultOrderedDict, :Order
         $DefaultDict() = throw(ArgumentError("$DefaultDict: no default specified"))
         $DefaultDict(k,v) = throw(ArgumentError("$DefaultDict: no default specified"))
 
-        # TODO: these mimic similar Dict constructors, but may not be needed
-        $DefaultDict{K,V,F}(default::F, ks::AbstractArray{K}, vs::AbstractArray{V}) = $DefaultDict{K,V,F}(default,ks,vs)
-        $DefaultDict{F}(default::F,ks,vs) = $DefaultDict{Any,Any,F}(default, ks, vs)
-
         # syntax entry points
         $DefaultDict{F}(default::F) = $DefaultDict{Any,Any,F}(default)
-        $DefaultDict{K,V,F}(::Type{K}, ::Type{V}, default::F) = $DefaultDict{K,V,F}(default)
         $DefaultDict{K,V,F}(default::F, kv::AbstractArray{Tuple{K,V}}) = $DefaultDict{K,V,F}(default, kv)
         $DefaultDict{K,V,F}(default::F, ps::Pair{K,V}...) = $DefaultDict{K,V,F}(default, ps...)
 
         $DefaultDict{F}(default::F, d::Associative) = ((K,V)= (Base.keytype(d), Base.valtype(d)); $DefaultDict{K,V,F}(default, HashDict(d)))
+
+        # Constructor syntax: DefaultDictBase{Int,Float64}(default)
+        @compat (::Type{$DefaultDict{K,V}}){K,V}() = throw(ArgumentError("$DefaultDict: no default specified"))
+        @compat (::Type{$DefaultDict{K,V}}){K,V,F}(default::F) = $DefaultDict{K,V,F}(default)
 
         ## Functions
 
@@ -111,7 +105,7 @@ for (DefaultDict,O) in [(:DefaultDict, :Unordered), (:DefaultOrderedDict, :Order
 end
 
 
-## If/when a SortedDict becomes available, this should be uncommented to provide a DefaultSortedDict
+## This should be uncommented to provide a DefaultSortedDict
 
 # immutable DefaultSortedDict{K,V,F} <: Associative{K,V}
 #     d::DefaultDictBase{K,V,F,SortedDict{K,V}}

--- a/test/test_default_dict.jl
+++ b/test/test_default_dict.jl
@@ -5,11 +5,12 @@
 # construction
 @test_throws ArgumentError DefaultDict()
 @test_throws ArgumentError DefaultDict(AbstractString, Int)
+@test_throws ArgumentError DefaultDict{AbstractString, Int}()
 
 @test isa(DefaultDict(0.0, 1 => 1.0), DefaultDict{Int,Float64,Float64})
 
 # empty dictionary
-d = DefaultDict(Char, Int, 1)
+d = DefaultDict{Char, Int}(1)
 @test length(d) == 0
 @test isempty(d)
 @test d['c'] == 1
@@ -65,10 +66,10 @@ s = similar(d)
 
 # construction
 @test_throws ArgumentError DefaultOrderedDict()
-@test_throws ArgumentError DefaultOrderedDict(AbstractString, Int)
+@test_throws ArgumentError DefaultOrderedDict{AbstractString, Int}()
 
 # empty dictionary
-d = DefaultOrderedDict(Char, Int, 1)
+d = DefaultOrderedDict{Char, Int}(1)
 @test length(d) == 0
 @test isempty(d)
 @test d['c'] == 1

--- a/test/test_default_dict.jl
+++ b/test/test_default_dict.jl
@@ -1,3 +1,21 @@
+import DataStructures: DefaultDictBase
+
+#####################
+# DefaultDictBase
+#####################
+
+#construction
+@test_throws ArgumentError DefaultDictBase()
+@test isa(DefaultDictBase(0.0), DefaultDictBase{Any, Any, Float64, Dict{Any, Any}})
+@test isa(DefaultDictBase(0.0, 1 => 1.0), DefaultDictBase{Int, Float64, Float64, Dict{Int, Float64}})
+@test isa(DefaultDictBase(0.0, [(1, 1.0)]), DefaultDictBase{Int, Float64, Float64, Dict{Int, Float64}})
+#@test isa(DefaultDictBase(0.0, Dict()), DefaultDictBase{Any, Any, Float64, Dict{Any, Any}}))
+
+ddb = DefaultDictBase{Int, Float64}(0.0)
+@test isa(ddb, DefaultDictBase{Int, Float64, Float64, Dict{Int,Float64}})
+@test isa(DefaultDictBase(1.0, ddb), DefaultDictBase{Int, Float64, Float64, Dict{Int,Float64}})
+
+
 ##############
 # DefaultDicts
 ##############
@@ -7,7 +25,7 @@
 @test_throws ArgumentError DefaultDict(AbstractString, Int)
 @test_throws ArgumentError DefaultDict{AbstractString, Int}()
 
-@test isa(DefaultDict(0.0, 1 => 1.0), DefaultDict{Int,Float64,Float64})
+@test isa(DefaultDict(0.0, 1 => 1.0), DefaultDict{Int, Float64, Float64})
 
 # empty dictionary
 d = DefaultDict{Char, Int}(1)
@@ -59,6 +77,9 @@ s = similar(d)
 @test typeof(s) === typeof(d)
 @test s.d.default == d.d.default
 
+# Alternate constructor
+@test isa(DefaultDict(0.0), DefaultDict{Any, Any, Float64})
+@test isa(DefaultDict(0.0, [(1, 1.0)]), DefaultDict{Int, Float64, Float64})
 
 #####################
 # DefaultOrderedDicts
@@ -107,3 +128,7 @@ end
 s = similar(d)
 @test typeof(s) === typeof(d)
 @test s.d.default == d.d.default
+
+# Alternate constructor
+@test isa(DefaultOrderedDict(0.0), DefaultOrderedDict{Any, Any, Float64})
+@test isa(DefaultOrderedDict(0.0, [(1, 1.0)]), DefaultOrderedDict{Int, Float64, Float64})


### PR DESCRIPTION
* `Dict` and `OrderedDict` constructors have changed, and
  `DefaultDict`/`DefaultOrderedDict` haven't kept up.
* The changes:

   Dict(KeyType, ValType) => Dict{KeyType, ValType}()
   Dict(ks, vs) is deprectated

* This deprecates working versions of these from DefaultDict
  and friends, and fixes broken calls which attempt to
  use these old constructors.