### PR TITLE
Revert "Remove HashDict"

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -67,6 +67,7 @@ module DataStructures
     include("heaps.jl")
 
     include("dict_support.jl")
+    include("hash_dict.jl")
     include("ordered_dict.jl")
     include("ordered_set.jl")
     include("default_dict.jl")

--- a/src/default_dict.jl
+++ b/src/default_dict.jl
@@ -4,7 +4,7 @@
 # DefaultDictBase is the main class used to in Default*Dicts.
 #
 # Each related (immutable) Default*Dict class contains a single
-# DefaultDictBase object as a member, and delegates almost all
+# DefautlDictBase object as a member, and delegates almost all
 # functions to this object.
 #
 # The main rationale for doing this instead of using type aliases is
@@ -63,17 +63,16 @@ getindex(d::DefaultDictBase, key) = get!(d.d, key, d.default)
 # wrappers around a DefaultDictBase object, and delegate all functions
 # to that object
 
-for _Dict in [:Dict, :OrderedDict]
-    DefaultDict = Symbol("Default"*string(_Dict))
+for (DefaultDict,O) in [(:DefaultDict, :Unordered), (:DefaultOrderedDict, :Ordered)]
     @eval begin
         immutable $DefaultDict{K,V,F} <: Associative{K,V}
-            d::DefaultDictBase{K,V,F,$_Dict{K,V}}
+            d::DefaultDictBase{K,V,F,HashDict{K,V,$O}}
 
-            $DefaultDict(x, ps::Pair{K,V}...) = new(DefaultDictBase{K,V,F,$_Dict{K,V}}(x, ps...))
-            $DefaultDict(x, kv::AbstractArray{Tuple{K,V}}) = new(DefaultDictBase{K,V,F,$_Dict{K,V}}(x, kv))
+            $DefaultDict(x, ps::Pair{K,V}...) = new(DefaultDictBase{K,V,F,HashDict{K,V,$O}}(x, ps...))
+            $DefaultDict(x, kv::AbstractArray{Tuple{K,V}}) = new(DefaultDictBase{K,V,F,HashDict{K,V,$O}}(x, kv))
             $DefaultDict(x, d::$DefaultDict) = $DefaultDict(x, d.d)
-            $DefaultDict(x, d::$_Dict) = new(DefaultDictBase{K,V,F,$_Dict{K,V}}(x, d))
-            $DefaultDict(x) = new(DefaultDictBase{K,V,F,$_Dict{K,V}}(x))
+            $DefaultDict(x, d::HashDict) = new(DefaultDictBase{K,V,F,HashDict{K,V,$O}}(x, d))
+            $DefaultDict(x) = new(DefaultDictBase{K,V,F,HashDict{K,V,$O}}(x))
         end
 
         ## Constructors
@@ -86,7 +85,7 @@ for _Dict in [:Dict, :OrderedDict]
         $DefaultDict{K,V,F}(default::F, kv::AbstractArray{Tuple{K,V}}) = $DefaultDict{K,V,F}(default, kv)
         $DefaultDict{K,V,F}(default::F, ps::Pair{K,V}...) = $DefaultDict{K,V,F}(default, ps...)
 
-        $DefaultDict{F}(default::F, d::Associative) = ((K,V)= (Base.keytype(d), Base.valtype(d)); $DefaultDict{K,V,F}(default, $_Dict(d)))
+        $DefaultDict{F}(default::F, d::Associative) = ((K,V)= (Base.keytype(d), Base.valtype(d)); $DefaultDict{K,V,F}(default, HashDict(d)))
 
         # Constructor syntax: DefaultDictBase{Int,Float64}(default)
         @compat (::Type{$DefaultDict{K,V}}){K,V}() = throw(ArgumentError("$DefaultDict: no default specified"))

--- a/src/dict_support.jl
+++ b/src/dict_support.jl
@@ -1,6 +1,6 @@
-# support functions
+# support function
 
-# These functions are defined in Base, but are not exported,
-# so they are redefined here.
+# This is defined in Base, but probably not meant for external consumption,
+# so it's redefined here.
 _tablesz(x::Integer) = x < 16 ? 16 : one(x)<<((sizeof(x)<<3)-leading_zeros(x-1))
-hashindex(key, sz) = (reinterpret(Int,(hash(key))) & (sz-1)) + 1
+

--- a/src/hash_dict.jl
+++ b/src/hash_dict.jl
@@ -1,0 +1,538 @@
+# HashDict
+
+import Base: KeyIterator, ValueIterator, haskey, get, getkey, delete!,
+             pop!, empty!, filter!, setindex!, getindex, similar,
+             sizehint!, length, filter, isempty, start, next, done,
+             keys, values, skip_deleted, serialize, deserialize
+
+import Base.Serializer: serialize_type
+const SerState =  Base.Serializer.SerializationState
+
+typealias Unordered Void
+typealias Ordered   Int
+
+type HashDict{K,V,O<:Union{Ordered,Unordered}} <: Associative{K,V}
+    slots::Array{UInt8,1}
+    keys::Array{K,1}
+    vals::Array{V,1}
+    idxs::Array{O,1}
+    order::Array{O,1}
+    ndel::Int
+    count::Int
+    deleter::Function
+
+    function HashDict()
+        n = 16
+        new(zeros(UInt8,n), Array(K,n), Array(V,n), Array(O,n), Array(O,0), 0, 0, identity)
+    end
+
+    HashDict(p::Pair) = setindex!(HashDict{K,V,O}(), p.second, p.first)
+    function HashDict(ps::Pair...)
+        h = HashDict{K,V,O}()
+        sizehint!(h, length(ps))
+        for p in ps
+            h[p.first] = p.second
+        end
+        return h
+    end
+
+    function HashDict(ks, vs)
+        Base.warn_once("HashDict(kv,vs) is deprecated, use HashDict(zip(ks,vs)) instead")
+
+        n = length(ks)
+        h = HashDict{K,V,O}()
+        for i=1:n
+            h[ks[i]] = vs[i]
+        end
+        return h
+    end
+
+    function HashDict(kv)
+        h = HashDict{K,V,O}()
+        sizehint!(h, length(kv))
+        for (k,v) in kv
+            h[k] = v
+        end
+        return h
+    end
+end
+
+HashDict() = HashDict{Any,Any,Unordered}()
+HashDict(kv::Tuple{}) = HashDict()
+HashDict(kv) = hash_dict_with_eltype(kv, eltype(kv))
+
+hash_dict_with_eltype{K,V}(kv, ::Type{Tuple{K,V}}) = HashDict{K,V}(kv)
+hash_dict_with_eltype(kv, t) = HashDict{Any,Any}(kv)
+
+HashDict{K,V}(kv::AbstractArray{Tuple{K,V}}) = HashDict{K,V,Unordered}(kv)
+if VERSION >= v"0.4.0-dev+980"
+    HashDict{K,V}(ps::Pair{K,V}...) = HashDict{K,V,Unordered}(ps...)
+    HashDict{K,V}(kv::Tuple{Vararg{Pair{K,V}}})         = HashDict{K,V}(kv)
+    HashDict{K}(kv::Tuple{Vararg{Pair{K}}})             = HashDict{K,Any}(kv)
+    HashDict{V}(kv::Tuple{Vararg{Pair{TypeVar(:K),V}}}) = HashDict{Any,V}(kv)
+    HashDict(kv::Tuple{Vararg{Pair}})                   = HashDict{Any,Any}(kv)
+
+    HashDict{K,V}(kv::AbstractArray{Pair{K,V}}) = HashDict{K,V}(kv)
+
+    hash_dict_with_eltype{K,V}(kv, ::Type{Pair{K,V}}) = HashDict{K,V}(kv)
+end
+
+# TODO: these could be more efficient
+HashDict{K,V,O}(d::HashDict{K,V,O}) = HashDict{K,V,O}(collect(d))
+HashDict{K,V}(d::Associative{K,V}) = HashDict{K,V,Unordered}(collect(d))
+
+similar{K,V,O}(d::HashDict{K,V,O}) = HashDict{K,V,O}()
+
+function serialize(s::SerState, t::HashDict)
+    serialize_type(s, typeof(t))
+    serialize(s, Int32(length(t)))
+    for (k,v) in t
+        serialize(s, k)
+        serialize(s, v)
+    end
+end
+
+function deserialize{K,V,O}(s::SerState, T::Type{HashDict{K,V,O}})
+    n = deserialize(s)
+    t = T(); sizehint!(t, n)
+    for i = 1:n
+        k = deserialize(s)
+        v = deserialize(s)
+        t[k] = v
+    end
+    return t
+end
+
+hashindex(key, sz) = (reinterpret(Int,(hash(key))) & (sz-1)) + 1
+
+isslotempty(h::HashDict, i::Int) = h.slots[i] == 0x0
+isslotfilled(h::HashDict, i::Int) = h.slots[i] == 0x1
+isslotmissing(h::HashDict, i::Int) = h.slots[i] == 0x2
+
+function rehash{K,V}(h::HashDict{K,V,Unordered}, newsz)
+    newsz = _tablesz(newsz)
+
+    if h.count == 0
+        resize!(h.slots, newsz)
+        fill!(h.slots, 0)
+        resize!(h.keys, newsz)
+        resize!(h.vals, newsz)
+        h.ndel = 0
+        return h
+    end
+
+    olds = h.slots
+    oldk = h.keys
+    oldv = h.vals
+    sz = length(olds)
+
+    slots = zeros(UInt8,newsz)
+    keys = Array(K, newsz)
+    vals = Array(V, newsz)
+    count0 = h.count
+    count = 0
+
+    for i = 1:sz
+        if olds[i] == 0x1
+            k = oldk[i]
+            v = oldv[i]
+            index = hashindex(k, newsz)
+            while slots[index] != 0
+                index = (index & (newsz-1)) + 1
+            end
+            slots[index] = 0x1
+            keys[index] = k
+            vals[index] = v
+            count += 1
+
+            if h.count != count0
+                # if items are removed by finalizers, retry
+                return rehash(h, newsz)
+            end
+        end
+    end
+
+    h.slots = slots
+    h.keys = keys
+    h.vals = vals
+    h.count = count
+    h.ndel = 0
+
+    return h
+end
+
+function rehash{K,V}(h::HashDict{K,V,Ordered}, newsz)
+    newsz = _tablesz(newsz)
+
+    if h.count == 0
+        resize!(h.slots, newsz)
+        fill!(h.slots, 0)
+        resize!(h.keys, newsz)
+        resize!(h.vals, newsz)
+        resize!(h.idxs, newsz)
+        resize!(h.order, 0)
+        h.ndel = 0
+        return h
+    end
+
+    _compact_order(h)
+
+    olds = h.slots
+    oldk = h.keys
+    oldv = h.vals
+    oldi = h.idxs
+    oldo = h.order
+    sz = length(olds)
+
+    slots = zeros(UInt8,newsz)
+    keys = Array(K, newsz)
+    vals = Array(V, newsz)
+    idxs = Array(Int, newsz)
+    order = Array(Int, h.count)
+    count0 = h.count
+    count = 0
+
+    for i = 1:sz
+        if olds[i] == 0x1
+            k = oldk[i]
+            v = oldv[i]
+            idx = oldi[i]
+            index = hashindex(k, newsz)
+            while slots[index] != 0
+                index = (index & (newsz-1)) + 1
+            end
+            slots[index] = 0x1
+            keys[index] = k
+            vals[index] = v
+            idxs[index] = idx
+            order[idx] = index
+            count += 1
+
+            if h.count != count0
+                # if items are removed by finalizers, retry
+                return rehash(h, newsz)
+            end
+        end
+    end
+
+    h.slots = slots
+    h.keys = keys
+    h.vals = vals
+    h.idxs = idxs
+    h.order = order
+    h.count = count
+    h.ndel = 0
+
+    return h
+end
+
+
+function _compact_order{K,V}(h::HashDict{K,V,Ordered})
+    h.count == length(h.order) && return
+
+    local i,j
+
+    for i = 1:length(h.order)-1
+        h.order[i] == 0 && break
+    end
+
+    for j = i+1:length(h.order)
+        h.order[j] != 0 && break
+    end
+
+    for k = j:length(h.order)
+        idx = h.order[k]
+        if idx > 0
+            h.order[i] = idx
+            h.idxs[idx] = i
+            i += 1
+        end
+    end
+
+    resize!(h.order, h.count)
+
+    nothing
+end
+
+function sizehint!(d::HashDict, newsz)
+    oldsz = length(d.slots)
+    if newsz <= oldsz
+        # todo: shrink
+        # be careful: rehash() assumes everything fits. it was only designed
+        # for growing.
+        return d
+    end
+    # grow at least 25%
+    newsz = max(newsz, (oldsz*5)>>2)
+    rehash(d, newsz)
+end
+
+function empty!{K,V}(h::HashDict{K,V})
+    fill!(h.slots, 0x0)
+    sz = length(h.slots)
+    h.keys = Array(K, sz)
+    h.vals = Array(V, sz)
+    h.ndel = 0
+    h.count = 0
+    return h
+end
+
+function empty!{K,V}(h::HashDict{K,V,Ordered})
+    sz = length(h.slots)
+    fill!(h.slots, 0x0)
+    h.keys = Array(K, sz)
+    h.vals = Array(V, sz)
+    h.idxs = Array(Int, sz)
+    h.order = Array(Int, 0)
+    h.ndel = 0
+    h.count = 0
+    return h
+end
+
+# get the index where a key is stored, or -1 if not present
+function ht_keyindex{K,V}(h::HashDict{K,V}, key)
+    sz = length(h.keys)
+    iter = 0
+    maxprobe = max(16, sz>>6)
+    index = hashindex(key, sz)
+    keys = h.keys
+
+    while true
+        if isslotempty(h,index)
+            break
+        end
+        if !isslotmissing(h,index) && isequal(key,keys[index])
+            return index
+        end
+
+        index = (index & (sz-1)) + 1
+        iter+=1
+        iter > maxprobe && break
+    end
+
+    return -1
+end
+
+# get the index where a key is stored, or -pos if not present
+# and the key would be inserted at pos
+# This version is for use by setindex! and get!
+function ht_keyindex2{K,V}(h::HashDict{K,V}, key)
+    sz = length(h.keys)
+
+    if h.ndel >= ((3*sz)>>2) || h.count*3 > sz*2
+        # > 3/4 deleted or > 2/3 full
+        rehash(h, h.count > 64000 ? h.count*2 : h.count*4)
+        sz = length(h.keys)  # rehash may resize the table at this point!
+    end
+
+    iter = 0
+    maxprobe = max(16, sz>>6)
+    index = hashindex(key, sz)
+    avail = 0
+    keys = h.keys
+
+    while true
+        if isslotempty(h,index)
+            avail < 0 && return avail
+            return -index
+        end
+
+        if isslotmissing(h,index)
+            if avail == 0
+                # found an available slot, but need to keep scanning
+                # in case "key" already exists in a later collided slot.
+                avail = -index
+            end
+        elseif isequal(key, keys[index])
+            return index
+        end
+
+        index = (index & (sz-1)) + 1
+        iter+=1
+        iter > maxprobe && break
+    end
+
+    avail < 0 && return avail
+
+    rehash(h, h.count > 64000 ? sz*2 : sz*4)
+
+    return ht_keyindex2(h, key)
+end
+
+function _setindex!(h::HashDict, v, key, index)
+    h.slots[index] = 0x1
+    h.keys[index] = key
+    h.vals[index] = v
+    h.count += 1
+    return h
+end
+
+function _setindex!{K,V}(h::HashDict{K,V,Ordered}, v, key, index)
+    h.slots[index] = 0x1
+    h.keys[index] = key
+    h.vals[index] = v
+    push!(h.order, index)
+    h.idxs[index] = length(h.order)
+    h.count += 1
+    return h
+end
+
+function setindex!{K,V}(h::HashDict{K,V}, v0, key0)
+    key = convert(K,key0)
+    if !isequal(key,key0)
+        throw(ArgumentError("$key0 is not a valid key for type $K"))
+    end
+    v   = convert(V,  v0)
+
+    index = ht_keyindex2(h, key)
+
+    if index > 0
+        h.vals[index] = v
+    else
+        _setindex!(h, v, key, -index)
+    end
+
+    return h
+end
+
+function get!{K,V}(h::HashDict{K,V}, key0, default)
+    key = convert(K,key0)
+    if !isequal(key,key0)
+        throw(ArgumentError("$key0 is not a valid key for type $K"))
+    end
+
+    index = ht_keyindex2(h, key)
+
+    index > 0 && return h.vals[index]
+
+    v = convert(V,  default)
+    _setindex!(h, v, key, -index)
+    return v
+end
+
+# TODO: this makes it challenging to have V<:Base.Callable
+function get!{K,V,F<:Base.Callable}(h::HashDict{K,V}, key0, default::F)
+    key = convert(K,key0)
+    if !isequal(key,key0)
+        throw(ArgumentError("$key0 is not a valid key for type $K"))
+    end
+
+    index = ht_keyindex2(h, key)
+
+    index > 0 && return h.vals[index]
+
+    v = convert(V,  default())
+    _setindex!(h, v, key, -index)
+    return v
+end
+
+function getindex{K,V}(h::HashDict{K,V}, key)
+    index = ht_keyindex(h, key)
+    return (index<0) ? throw(KeyError(key)) : h.vals[index]::V
+end
+
+function get{K,V}(h::HashDict{K,V}, key, deflt)
+    index = ht_keyindex(h, key)
+    return (index<0) ? deflt : h.vals[index]::V
+end
+
+haskey(h::HashDict, key) = (ht_keyindex(h, key) >= 0)
+contains{T<:HashDict}(v::KeyIterator{T}, key) = (ht_keyindex(v.dict, key) >= 0)
+
+function getkey{K,V}(h::HashDict{K,V}, key, deflt)
+    index = ht_keyindex(h, key)
+    return (index<0) ? deflt : h.keys[index]::K
+end
+
+function _pop!(h::HashDict, index)
+    val = h.vals[index]
+    _delete!(h, index)
+    return val
+end
+
+function pop!(h::HashDict, key)
+    index = ht_keyindex(h, key)
+    index > 0 ? _pop!(h, index) : throw(KeyError(key))
+end
+
+function pop!(h::HashDict, key, default)
+    index = ht_keyindex(h, key)
+    index > 0 ? _pop!(h, index) : default
+end
+
+
+function _delete!(h::HashDict, index)
+    h.slots[index] = 0x2
+    ccall(:jl_arrayunset, Void, (Any, UInt), h.keys, index-1)
+    ccall(:jl_arrayunset, Void, (Any, UInt), h.vals, index-1)
+    h.ndel += 1
+    h.count -= 1
+    return h
+end
+
+function _delete!{K,V}(h::HashDict{K,V,Ordered}, index)
+    h.slots[index] = 0x2
+    ccall(:jl_arrayunset, Void, (Any, UInt), h.keys, index-1)
+    ccall(:jl_arrayunset, Void, (Any, UInt), h.vals, index-1)
+    h.order[h.idxs[index]] = 0
+    h.ndel += 1
+    h.count -= 1
+    return h
+end
+
+function delete!(h::HashDict, key)
+    index = ht_keyindex(h, key)
+    index > 0 && _delete!(h, index)
+    return h
+end
+
+function skip_deleted{K,V,O}(h::HashDict{K,V,O}, i)
+    L = length(h.slots)
+    while i<=L && !isslotfilled(h,i)
+        i += 1
+    end
+    return i
+end
+
+function skip_deleted{K,V}(h::HashDict{K,V,Ordered}, i)
+    L = length(h.order)
+    while i<=L && h.order[i] == 0
+        i += 1
+    end
+    return i
+end
+
+start(t::HashDict) = skip_deleted(t, 1)
+done(t::HashDict, i) = done(t.vals, i)
+if VERSION >= v"0.4.0-dev+980"
+    next(t::HashDict, i) = (Pair(t.keys[i],t.vals[i]), skip_deleted(t,i+1))
+else
+    next(t::HashDict, i) = ((t.keys[i],t.vals[i]), skip_deleted(t,i+1))
+end
+
+
+done{K,V}(t::HashDict{K,V,Ordered}, i) = done(t.order, i)
+if VERSION >= v"0.4.0-dev+980"
+    next{K,V}(t::HashDict{K,V,Ordered}, i) = (Pair(t.keys[t.order[i]],t.vals[t.order[i]]), skip_deleted(t,i+1))
+else
+    next{K,V}(t::HashDict{K,V,Ordered}, i) = ((t.keys[t.order[i]],t.vals[t.order[i]]), skip_deleted(t,i+1))
+end
+
+isempty(t::HashDict) = (t.count == 0)
+length(t::HashDict) = t.count
+
+next(v::KeyIterator{HashDict}, i) = (v.dict.keys[i], skip_deleted(v.dict,i+1))
+next(v::ValueIterator{HashDict}, i) = (v.dict.vals[i], skip_deleted(v.dict,i+1))
+
+next{K,V}(v::KeyIterator{HashDict{K,V,Ordered}}, i) = (v.dict.keys[v.dict.order[i]], skip_deleted(v.dict,i+1))
+next{K,V}(v::ValueIterator{HashDict{K,V,Ordered}}, i) = (v.dict.vals[v.dict.order[i]], skip_deleted(v.dict,i+1))
+
+if VERSION >= v"0.4.0-dev+980"
+    push!(t::HashDict, p::Pair) = setindex!(t, p.second, p.first)
+    push!(t::HashDict, p::Pair, q::Pair) = push!(push!(t, p), q)
+    push!(t::HashDict, p::Pair, q::Pair, r::Pair...) = push!(push!(push!(t, p), q), r...)
+end
+
+push!(d::HashDict, p) = setindex!(d, p[2], p[1])
+push!(d::HashDict, p, q) = push!(push!(d, p), q)
+push!(d::HashDict, p, q, r...) = push!(push!(push!(d, p), q), r...)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,3 @@
 BaseTestNext
 Primes 0.1.1
+Compat 0.9.5

--- a/test/test_circ_deque.jl
+++ b/test/test_circ_deque.jl
@@ -1,4 +1,5 @@
-using DataStructures
+using DataStructures, Compat
+using Compat: String
 if VERSION >= v"0.5.0-dev+7720"
     using Base.Test
 else
@@ -29,9 +30,9 @@ end
     @test back(D) === 5
     io = IOBuffer()
     print(io, Int)
-    intstr = takebuf_string(io)
+    intstr = String(take!(io))
     print(io, D)
-    @test takebuf_string(io) == "CircularDeque{$intstr}([2,3,4,5])"
+    @test String(take!(io)) == "CircularDeque{$intstr}([2,3,4,5])"
     push!(D, 6)
     @test front(D) === 2
     @test back(D) === 6

--- a/test/test_priorityqueue.jl
+++ b/test/test_priorityqueue.jl
@@ -106,5 +106,5 @@ for priority in values(priorities)
 end
 @test issorted([heappop!(xs) for _ in length(priorities)])
 
-@test Base.Collections.isheap([1, 2, 3], Base.Order.Forward)
-@test !Base.Collections.isheap([1, 2, 3], Base.Order.Reverse)
+@test isheap([1, 2, 3], Base.Order.Forward)
+@test !isheap([1, 2, 3], Base.Order.Reverse)


### PR DESCRIPTION
This reverts commit 1681e24c8813013d5d469a3cb5fa5ff65a0a3f3e.

cc @kmsquire, https://github.com/JuliaLang/DataStructures.jl/pull/224 managed to break Gadfly with a `no method matching push!(::Gadfly.Guide.##86#91, ::Tuple{Array{Compose.Context,1},Int64}}`