### PR TITLE
Implement start/next/done for CircularDeque

### DIFF
--- a/src/circ_deque.jl
+++ b/src/circ_deque.jl
@@ -70,20 +70,25 @@ end
     v
 end
 
-@inline function Base.getindex(D::CircularDeque, i::Integer)
-    @compat @boundscheck 1 <= i <= D.n || throw(BoundsError())
+# getindex sans bounds checking
+@inline function _unsafe_getindex(D::CircularDeque, i::Integer)
     j = D.first + i - 1
     if j > D.capacity
         j -= D.capacity
     end
     @inbounds ret = D.buffer[j]
-    ret
+    return ret
+end
+
+@inline function Base.getindex(D::CircularDeque, i::Integer)
+    @compat @boundscheck 1 <= i <= D.n || throw(BoundsError())
+    return _unsafe_getindex(D, i)
 end
 
 # Iteration via getindex
-Base.start(d::CircularDeque) = 1
-Base.next(d::CircularDeque, i) = (d[i], i+1)
-Base.done(d::CircularDeque, i) = i == length(d) + 1
+@inline Base.start(d::CircularDeque) = 1
+@inline Base.next(d::CircularDeque, i) = (_unsafe_getindex(d, i), i+1)
+@inline Base.done(d::CircularDeque, i) = i == d.n + 1
 
 function Base.show{T}(io::IO, D::CircularDeque{T})
     print(io, "CircularDeque{$T}([")

--- a/src/circ_deque.jl
+++ b/src/circ_deque.jl
@@ -80,6 +80,11 @@ end
     ret
 end
 
+# Iteration via getindex
+Base.start(d::CircularDeque) = 1
+Base.next(d::CircularDeque, i) = (d[i], i+1)
+Base.done(d::CircularDeque, i) = i == length(d) + 1
+
 function Base.show{T}(io::IO, D::CircularDeque{T})
     print(io, "CircularDeque{$T}([")
     for i = 1:length(D)

--- a/test/test_circ_deque.jl
+++ b/test/test_circ_deque.jl
@@ -78,6 +78,11 @@ end
     empty!(D)
     unshift!(D, 40)
     @test front(D) == back(D) == 40
+
+    # Test iteration over loop
+    D = CircularDeque{Int}(5)
+    for i in 1:5 push!(D, i) end
+    @test collect(i for i in D) == collect(1:5)
 end
 
 nothing

--- a/test/test_circ_deque.jl
+++ b/test/test_circ_deque.jl
@@ -82,7 +82,7 @@ end
     # Test iteration over loop
     D = CircularDeque{Int}(5)
     for i in 1:5 push!(D, i) end
-    @test collect(i for i in D) == collect(1:5)
+    @test collect([i for i in D]) == collect(1:5)
 end
 
 nothing


### PR DESCRIPTION
Hi,

This PR simply adds the `start`/`next`/`done` methods required for idiomatic for-loop iteration over CircularDeques.

I'm a relative Julia novice, so any tips (especially regarding performance) are appreciated.

Cheers,
Kevin