### PR TITLE
Add Base.unshift! for CircularBuffers

### DIFF
--- a/src/circular_buffer.jl
+++ b/src/circular_buffer.jl
@@ -43,6 +43,17 @@ function Base.push!(cb::CircularBuffer, data)
     cb
 end
 
+function Base.unshift!(cb::CircularBuffer, data)
+    # if full, decrement and overwrite, otherwise unshift
+    if length(cb) == cb.capacity
+        cb.first = (cb.first == 1 ? cb.capacity : cb.first - 1)
+        cb[1] = data
+    else
+        unshift!(cb.buffer, data)
+    end
+    cb
+end
+
 function Base.append!(cb::CircularBuffer, datavec::AbstractVector)
     # push at most `capacity` items
     n = length(datavec)

--- a/test/test_circular_buffer.jl
+++ b/test/test_circular_buffer.jl
@@ -6,38 +6,50 @@ else
     const Test = BaseTestNext
 end
 
-cb = CircularBuffer{Int}(5)
-@test length(cb) == 0
-@test capacity(cb) == 5
-# throws ArgumentError on v0.4 and BoundsError on v0.5 (diverged at 0.5.0-dev+5230)
-if VERSION >= v"0.5.0-dev+5230"
-    @test_throws BoundsError first(cb)
-else
-    @test_throws ArgumentError first(cb)
+@testset "CircularBuffer" begin
+    cb = CircularBuffer{Int}(5)
+    @test length(cb) == 0
+    @test capacity(cb) == 5
+    # throws ArgumentError on v0.4 and BoundsError on v0.5 (diverged at 0.5.0-dev+5230)
+    if VERSION >= v"0.5.0-dev+5230"
+        @test_throws BoundsError first(cb)
+    else
+        @test_throws ArgumentError first(cb)
+    end
+    @test isempty(cb) == true
+    @test isfull(cb) == false
+
+    push!(cb, 1)
+    @test length(cb) == 1
+    @test capacity(cb) == 5
+    @test isfull(cb) == false
+
+    append!(cb, 2:8)
+    @test length(cb) == capacity(cb)
+    @test size(cb) == (length(cb),)
+    @test isempty(cb) == false
+    @test isfull(cb) == true
+    @test convert(Array, cb) == Int[4,5,6,7,8]
+    @test cb[1] == 4
+    @test cb[2] == 5
+    @test cb[3] == 6
+    @test cb[4] == 7
+    @test cb[5] == 8
+    @test_throws BoundsError cb[6]
+    @test_throws BoundsError cb[3:6]
+    @test cb[3:4] == Int[6,7]
+    @test cb[[1,5]] == Int[4,8]
+
+    cb[3] = 999
+    @test convert(Array, cb) == Int[4,5,999,7,8]
+
+    # Test unshift
+    for i in 1:5
+        unshift!(cb, i)
+    end
+    arr = convert(Array, cb)
+    @test arr == Int[5, 4, 3, 2, 1]
+    for (idx, n) in enumerate(5:1)
+        @test arr[idx] == n
+    end
 end
-@test isempty(cb) == true
-@test isfull(cb) == false
-
-push!(cb, 1)
-@test length(cb) == 1
-@test capacity(cb) == 5
-@test isfull(cb) == false
-
-append!(cb, 2:8)
-@test length(cb) == capacity(cb)
-@test size(cb) == (length(cb),)
-@test isempty(cb) == false
-@test isfull(cb) == true
-@test convert(Array, cb) == Int[4,5,6,7,8]
-@test cb[1] == 4
-@test cb[2] == 5
-@test cb[3] == 6
-@test cb[4] == 7
-@test cb[5] == 8
-@test_throws BoundsError cb[6]
-@test_throws BoundsError cb[3:6]
-@test cb[3:4] == Int[6,7]
-@test cb[[1,5]] == Int[4,8]
-
-cb[3] = 999
-@test convert(Array, cb) == Int[4,5,999,7,8]

--- a/test/test_circular_buffer.jl
+++ b/test/test_circular_buffer.jl
@@ -44,7 +44,8 @@ end
     @test convert(Array, cb) == Int[4,5,999,7,8]
 
     # Test unshift
-    for i in 1:5
+    cb = CircularBuffer{Int}(5)  # New, empty one for full test coverage
+    for i in -5:5
         unshift!(cb, i)
     end
     arr = convert(Array, cb)


### PR DESCRIPTION
Hi,

This PR adds `unshift!` to circular buffers. I've also `@testset`-ified the tests, and added tests of unshifting items.

On an unrelated note, I notice that the extended functions for `CircularBuffer` (push, getindex, setindex etc.) are not `@inline`. Is there any point in inlining these?

Cheers,
K