### PR TITLE
RFC: Fix delegation for *Dict functions returning the underlying *Dict

### DIFF
--- a/src/default_dict.jl
+++ b/src/default_dict.jl
@@ -45,9 +45,12 @@ DefaultDictBase{F,D<:Associative}(default::F, d::D) = (K=keytype(d); V=valtype(d
 # Functions
 
 # most functions are simply delegated to the wrapped dictionary
-@delegate DefaultDictBase.d [ sizehint!, empty!, setindex!, get, haskey,
-                             getkey, pop!, delete!, start, done, next,
-                             isempty, length ]
+@delegate DefaultDictBase.d [ get, haskey, getkey, pop!,
+                              start, done, next, isempty, length ]
+
+# NOTE: push! is not included below, because the fallback version just
+#       calls setindex!
+@delegate_return_parent DefaultDictBase.d [ delete!, empty!, setindex!, sizehint! ]
 
 similar{K,V,F}(d::DefaultDictBase{K,V,F}) = DefaultDictBase{K,V,F}(d.default)
 in{T<:DefaultDictBase}(key, v::Base.KeyIterator{T}) = key in keys(v.dict.d)
@@ -94,10 +97,13 @@ for (DefaultDict,O) in [(:DefaultDict, :Unordered), (:DefaultOrderedDict, :Order
         ## Functions
 
         # Most functions are simply delegated to the wrapped DefaultDictBase object
-        @delegate $DefaultDict.d [ sizehint!, empty!, setindex!,
-                                   getindex, get, get!, haskey,
-                                   getkey, pop!, delete!, start, next,
+        @delegate $DefaultDict.d [ getindex, get, get!, haskey,
+                                   getkey, pop!, start, next,
                                    done, isempty, length ]
+
+        # NOTE: push! is not included below, because the fallback version just
+        #       calls setindex!
+        @delegate_return_parent $DefaultDict.d [ delete!, empty!, setindex!, sizehint! ]
 
         similar{K,V,F}(d::$DefaultDict{K,V,F}) = $DefaultDict{K,V,F}(d.d.default)
         in{T<:$DefaultDict}(key, v::Base.KeyIterator{T}) = key in keys(v.dict.d.d)
@@ -137,10 +143,10 @@ end
 
 ## Most functions are simply delegated to the wrapped DefaultDictBase object
 
-# @delegate DefaultSortedDict.d [ sizehint!, empty!, setindex!,
-#                            getindex, get, get!, haskey,
-#                            getkey, pop!, delete!, start, next,
-#                            done, isempty, length]
+# @delegate DefaultSortedDict.d [ getindex, get, get!, haskey,
+#                                 getkey, pop!, start, next,
+#                                 done, isempty, length]
+# @delegate_return_parent DefaultSortedDict.d [ delete!, empty!, setindex!, sizehint! ]
 
 # similar{K,V,F}(d::DefaultSortedDict{K,V,F}) = DefaultSortedDict{K,V,F}(d.d.default)
 # in{T<:DefaultSortedDict}(key, v::Base.KeyIterator{T}) = key in keys(v.dict.d.d)

--- a/src/delegate.jl
+++ b/src/delegate.jl
@@ -4,12 +4,28 @@ macro delegate(source, targets)
     fieldname = source.args[2].args[1]
     funcnames = targets.args
     n = length(funcnames)
-    fdefs = Array(Any, n)
+    fdefs = Vector{Any}(n)
     for i in 1:n
         funcname = esc(funcnames[i])
         fdefs[i] = quote
                      ($funcname)(a::($typename), args...) =
                        ($funcname)(a.$fieldname, args...)
+                   end
+    end
+    return Expr(:block, fdefs...)
+end
+
+macro delegate_return_parent(source, targets)
+    typename = esc(source.args[1])
+    fieldname = source.args[2].args[1]
+    funcnames = targets.args
+    n = length(funcnames)
+    fdefs = Vector{Any}(n)
+    for i in 1:n
+        funcname = esc(funcnames[i])
+        fdefs[i] = quote
+                     ($funcname)(a::($typename), args...) =
+                       (($funcname)(a.$fieldname, args...); a)
                    end
     end
     return Expr(:block, fdefs...)

--- a/test/test_default_dict.jl
+++ b/test/test_default_dict.jl
@@ -32,8 +32,9 @@ d = DefaultDict{Char, Int}(1)
 @test length(d) == 0
 @test isempty(d)
 @test d['c'] == 1
+@test setindex!(d, 10, 'd') === d
 @test !isempty(d)
-empty!(d)
+@test empty!(d) === d
 @test isempty(d)
 
 # access, modification
@@ -46,6 +47,7 @@ empty!(d)
 @test pop!(d, 'a') == 2
 @test isempty(d)
 
+@test sizehint!(d, 26) === d
 for c in 'a':'z'
     d[c] = c-'a'+1
 end
@@ -53,7 +55,7 @@ end
 @test d['z'] == 26
 @test d['@'] == 1
 @test length(d) == 27
-delete!(d, '@')
+@test delete!(d, '@') === d
 @test length(d) == 26
 
 for (k,v) in d
@@ -95,7 +97,7 @@ d = DefaultOrderedDict{Char, Int}(1)
 @test isempty(d)
 @test d['c'] == 1
 @test !isempty(d)
-empty!(d)
+@test empty!(d) === d
 @test isempty(d)
 
 # access, modification
@@ -108,6 +110,7 @@ empty!(d)
 @test pop!(d, 'a') == 2
 @test isempty(d)
 
+@test sizehint!(d, 26) === d
 for c in 'a':'z'
     d[c] = c-'a'+1
 end
@@ -115,7 +118,7 @@ end
 @test d['z'] == 26
 @test d['@'] == 1
 @test length(d) == 27
-delete!(d, '@')
+@test delete!(d, '@') === d
 @test length(d) == 26
 
 for (k,v) in d


### PR DESCRIPTION
* When called on an `Associative` container, `sizehint!`, `empty!`, and
  `setindex!` all return the container
* The `@delegate` macro is not aware of this, and instead returned
  the wrapped object when used to define, e.g., `DefaultDict`s
* Fixed by creating a second macro, `@delegate_return_parent`,
  which works like `@delegate`, but returns the parent container.

**Edit:** `delete!` also returns the container.