### PR TITLE
Julia 0.6 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ julia:
   - 0.4
   - 0.5
   - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
+# matrix:
+  # allow_failures:
+    # - julia: nightly
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/src/balanced_tree.jl
+++ b/src/balanced_tree.jl
@@ -125,15 +125,15 @@ type BalancedTree23{K, D, Ord <: Ordering}
     deletionchild::Array{Int,1}
     deletionleftkey::Array{K,1}
     function BalancedTree23(ord1::Ord)
-        tree1 = Array{TreeNode{K}}(1)
+        tree1 = Vector{TreeNode{K}}(1)
         initializeTree!(tree1)
-        data1 = Array{KDRec{K,D}}(2)
+        data1 = Vector{KDRec{K,D}}(2)
         initializeData!(data1)
         u1 = IntSet()
         push!(u1, 1, 2)
-        new(ord1, data1, tree1, 1, 1, Array{Int}(0), Array{Int}(0),
+        new(ord1, data1, tree1, 1, 1, Vector{Int}(0), Vector{Int}(0),
             u1,
-            Array{Int}(3), Array{K}(3))
+            Vector{Int}(3), Vector{K}(3))
     end
 end
 
@@ -243,8 +243,8 @@ function empty!(t::BalancedTree23)
     initializeTree!(t.tree)
     t.depth = 1
     t.rootloc = 1
-    t.freetreeinds = Array{Int}(0)
-    t.freedatainds = Array{Int}(0)
+    t.freetreeinds = Vector{Int}(0)
+    t.freedatainds = Vector{Int}(0)
     empty!(t.useddatacells)
     push!(t.useddatacells, 1, 2)
     nothing

--- a/src/balanced_tree.jl
+++ b/src/balanced_tree.jl
@@ -119,21 +119,21 @@ type BalancedTree23{K, D, Ord <: Ordering}
     depth::Int
     freetreeinds::Array{Int,1}
     freedatainds::Array{Int,1}
-    useddatacells::IntSet 
+    useddatacells::IntSet
     # The next two arrays are used as a workspace by the delete!
     # function.
     deletionchild::Array{Int,1}
     deletionleftkey::Array{K,1}
     function BalancedTree23(ord1::Ord)
-        tree1 = Array(TreeNode{K}, 1)
+        tree1 = Array{TreeNode{K}}(1)
         initializeTree!(tree1)
-        data1 = Array(KDRec{K,D}, 2)
+        data1 = Array{KDRec{K,D}}(2)
         initializeData!(data1)
         u1 = IntSet()
         push!(u1, 1, 2)
-        new(ord1, data1, tree1, 1, 1, Array(Int,0), Array(Int,0), 
-            u1, 
-            Array(Int,3), Array(K,3))
+        new(ord1, data1, tree1, 1, 1, Array{Int}(0), Array{Int}(0),
+            u1,
+            Array{Int}(3), Array{K}(3))
     end
 end
 
@@ -243,8 +243,8 @@ function empty!(t::BalancedTree23)
     initializeTree!(t.tree)
     t.depth = 1
     t.rootloc = 1
-    t.freetreeinds = Array(Int,0)
-    t.freedatainds = Array(Int,0)
+    t.freetreeinds = Array{Int}(0)
+    t.freedatainds = Array{Int}(0)
     empty!(t.useddatacells)
     push!(t.useddatacells, 1, 2)
     nothing

--- a/src/circ_deque.jl
+++ b/src/circ_deque.jl
@@ -11,7 +11,7 @@ type CircularDeque{T}
     last::Int
 end
 
-@compat (::Type{CircularDeque{T}}){T}(n::Int) = CircularDeque(Array{T}(n), n, 0, 1, n)
+@compat (::Type{CircularDeque{T}}){T}(n::Int) = CircularDeque(Vector{T}(n), n, 0, 1, n)
 
 Base.length(D::CircularDeque) = D.n
 Base.eltype{T}(::Type{CircularDeque{T}}) = T

--- a/src/classified_collections.jl
+++ b/src/classified_collections.jl
@@ -16,7 +16,7 @@ classified_lists(K::Type, V::Type) = ClassifiedCollections(K, Vector{V})
 classified_sets(K::Type, V::Type) = ClassifiedCollections(K, Set{V})
 classified_counters(K::Type, T::Type) = ClassifiedCollections(K, Accumulator{T, Int})
 
-_create_empty{T}(::Type{Vector{T}}) = Array{T}(0)
+_create_empty{T}(::Type{Vector{T}}) = Vector{T}(0)
 _create_empty{T}(::Type{Set{T}}) = Set{T}()
 _create_empty{T,V}(::Type{Accumulator{T,V}}) = Accumulator(T, V)
 

--- a/src/classified_collections.jl
+++ b/src/classified_collections.jl
@@ -16,7 +16,7 @@ classified_lists(K::Type, V::Type) = ClassifiedCollections(K, Vector{V})
 classified_sets(K::Type, V::Type) = ClassifiedCollections(K, Set{V})
 classified_counters(K::Type, T::Type) = ClassifiedCollections(K, Accumulator{T, Int})
 
-_create_empty{T}(::Type{Vector{T}}) = Array(T, 0)
+_create_empty{T}(::Type{Vector{T}}) = Array{T}(0)
 _create_empty{T}(::Type{Set{T}}) = Set{T}()
 _create_empty{T,V}(::Type{Accumulator{T,V}}) = Accumulator(T, V)
 

--- a/src/default_dict.jl
+++ b/src/default_dict.jl
@@ -79,10 +79,7 @@ next{T<:DefaultDictBase}(v::Base.ValueIterator{T}, i) = (v.dict.d.vals[i], Base.
 
 getindex(d::DefaultDictBase, key) = get!(d.d, key, d.default)
 
-const _K = TypeVar(:K)
-const _V = TypeVar(:V)
-
-function getindex{F<:Base.Callable}(d::DefaultDictBase{_K,_V,F}, key)
+function getindex{K,V,F<:Base.Callable}(d::DefaultDictBase{K,V,F}, key)
     return get!(d.d, key) do
         d.default()
     end

--- a/src/default_dict.jl
+++ b/src/default_dict.jl
@@ -14,6 +14,7 @@
 # subclassed.
 #
 
+_oldDefaultDictBase = """
 immutable DefaultDictBase{K,V,F,D} <: Associative{K,V}
     default::F
     d::D
@@ -27,6 +28,24 @@ immutable DefaultDictBase{K,V,F,D} <: Associative{K,V}
     DefaultDictBase(x::F, d::DefaultDictBase) = (check_D(D,K,V); DefaultDictBase(x, d.d))
     DefaultDictBase(x::F, d::D=D()) = (check_D(D,K,V); new(x, d))
 end
+"""
+
+_newDefaultDictBase = """
+immutable DefaultDictBase{K,V,F,D} <: Associative{K,V}
+    default::F
+    d::D
+
+    check_D(D,K,V) = (D <: Associative{K,V}) ||
+        throw(ArgumentError("Default dict must be <: Associative{K,V}"))
+
+    DefaultDictBase(x::F, kv::AbstractArray{Tuple{K,V}}) = (check_D(D,K,V); new(x, D(kv)))
+    DefaultDictBase(x::F, ps::Pair{K,V}...) = (check_D(D,K,V); new(x, D(ps...)))
+    (::Type{DefaultDictBase{K,V,F,D}}){K,V,F,D<:DefaultDictBase}(x::F, d::D) =
+        (check_D(D,K,V); DefaultDictBase(x, d.d))
+    DefaultDictBase(x::F, d::D = D()) = (check_D(D,K,V); new(x, d))
+end
+"""
+eval(VERSION < v"0.6.0-dev.2123" ? parse(_oldDefaultDictBase) : parse(_newDefaultDictBase))
 
 # Constructors
 

--- a/src/deque.jl
+++ b/src/deque.jl
@@ -14,7 +14,7 @@ type DequeBlock{T}
     next::DequeBlock{T}  # ref to next block
 
     function DequeBlock(capa::Int, front::Int)
-        data = Array(T, capa)
+        data = Vector{T}(capa)
         blk = new(data, capa, front, front-1)
         blk.prev = blk
         blk.next = blk

--- a/src/heaps.jl
+++ b/src/heaps.jl
@@ -67,7 +67,7 @@ include("heaps/arrays_as_heaps.jl")
 
 function extract_all!{VT}(h::AbstractHeap{VT})
     n = length(h)
-    r = Array(VT, n)
+    r = Vector{VT}(n)
     for i = 1 : n
         r[i] = pop!(h)
     end
@@ -76,7 +76,7 @@ end
 
 function extract_all_rev!{VT}(h::AbstractHeap{VT})
     n = length(h)
-    r = Array(VT, n)
+    r = Vector{VT}(n)
     for i = 1 : n
         r[n + 1 - i] = pop!(h)
     end
@@ -91,14 +91,14 @@ function nextreme{T, Comp}(comp::Comp, n::Int, arr::AbstractVector{T})
     elseif n >= length(arr)
         return sort(arr, lt = (x, y) -> compare(comp, y, x))
     end
-    
+
     buffer = BinaryHeap{T,Comp}(comp)
-    
+
     for i = 1 : n
         @inbounds xi = arr[i]
         push!(buffer, xi)
     end
-    
+
     for i = n + 1 : length(arr)
         @inbounds xi = arr[i]
         if compare(comp, top(buffer), xi)

--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -107,7 +107,7 @@ type BinaryHeap{T,Comp} <: AbstractHeap{T}
     valtree::Array{T}
 
     function BinaryHeap(comp::Comp)
-        new(comp, Array(T,0))
+        new(comp, Vector{T}(0))
     end
 
     function BinaryHeap(comp::Comp, xs)  # xs is an iterable collection of values

--- a/src/heaps/mutable_binary_heap.jl
+++ b/src/heaps/mutable_binary_heap.jl
@@ -127,8 +127,8 @@ function _make_mutable_binary_heap{Comp,T}(comp::Comp, ty::Type{T}, values)
     # make a static binary index tree from a list of values
 
     n = length(values)
-    nodes = Array(MutableBinaryHeapNode{T}, n)
-    nodemap = Array(Int, n)
+    nodes = Vector{MutableBinaryHeapNode{T}}(n)
+    nodemap = Vector{Int}(n)
 
     i::Int = 0
     for v in values
@@ -156,8 +156,8 @@ type MutableBinaryHeap{VT, Comp} <: AbstractMutableHeap{VT,Int}
     node_map::Vector{Int}
 
     function MutableBinaryHeap(comp::Comp)
-        nodes = Array(MutableBinaryHeapNode{VT}, 0)
-        node_map = Array(Int, 0)
+        nodes = Vector{MutableBinaryHeapNode{VT}}(0)
+        node_map = Vector{Int}(0)
         new(comp, nodes, node_map)
     end
 

--- a/src/ordered_dict.jl
+++ b/src/ordered_dict.jl
@@ -22,7 +22,7 @@ type OrderedDict{K,V} <: Associative{K,V}
     dirty::Bool
 
     function OrderedDict()
-        new(zeros(Int32,16), Array(K,0), Array(V,0), 0, false)
+        new(zeros(Int32,16), Vector{K}(0), Vector{V}(0), 0, false)
     end
     function OrderedDict(kv)
         h = OrderedDict{K,V}()
@@ -57,18 +57,22 @@ copy(d::OrderedDict) = OrderedDict(d)
 # OrderedDict{K,V}(kv::Tuple{Vararg{Tuple{K,V}}})          = OrderedDict{K,V}(kv)
 # OrderedDict{K  }(kv::Tuple{Vararg{Tuple{K,Any}}})        = OrderedDict{K,Any}(kv)
 # OrderedDict{V  }(kv::Tuple{Vararg{Tuple{Any,V}}})        = OrderedDict{Any,V}(kv)
+_oldOrderedDict1 = "OrderedDict{V}(kv::Tuple{Vararg{Pair{TypeVar(:K),V}}}) = OrderedDict{Any,V}(kv)"
+_newOrderedDict1 = "OrderedDict{V}(kv::Tuple{Vararg{Pair{K,V} where K}})   = OrderedDict{Any,V}(kv)"
 OrderedDict{K,V}(kv::Tuple{Vararg{Pair{K,V}}})         = OrderedDict{K,V}(kv)
 OrderedDict{K}(kv::Tuple{Vararg{Pair{K}}})             = OrderedDict{K,Any}(kv)
-OrderedDict{V}(kv::Tuple{Vararg{Pair{TypeVar(:K),V}}}) = OrderedDict{Any,V}(kv)
+eval(VERSION < v"0.6.0-dev.2123" ? parse(_oldOrderedDict1) : parse(_newOrderedDict1))
 OrderedDict(kv::Tuple{Vararg{Pair}})                   = OrderedDict{Any,Any}(kv)
 
 OrderedDict{K,V}(kv::AbstractArray{Tuple{K,V}}) = OrderedDict{K,V}(kv)
 OrderedDict{K,V}(kv::AbstractArray{Pair{K,V}})  = OrderedDict{K,V}(kv)
 OrderedDict{K,V}(kv::Associative{K,V})          = OrderedDict{K,V}(kv)
 
+_oldOrderedDict2 = "OrderedDict{V}(ps::Pair{TypeVar(:K),V}...,) = OrderedDict{Any,V}(ps)"
+_newOrderedDict2 = "OrderedDict{V}(ps::(Pair{K,V} where K)...,) = OrderedDict{Any,V}(ps)"
 OrderedDict{K,V}(ps::Pair{K,V}...)          = OrderedDict{K,V}(ps)
 OrderedDict{K}(ps::Pair{K}...,)             = OrderedDict{K,Any}(ps)
-OrderedDict{V}(ps::Pair{TypeVar(:K),V}...,) = OrderedDict{Any,V}(ps)
+eval(VERSION < v"0.6.0-dev.2123" ? parse(_oldOrderedDict2) : parse(_newOrderedDict2))
 OrderedDict(ps::Pair...)                    = OrderedDict{Any,Any}(ps)
 
 function OrderedDict(kv)

--- a/src/priorityqueue.jl
+++ b/src/priorityqueue.jl
@@ -32,7 +32,7 @@ type PriorityQueue{K,V,O<:Ordering} <: Associative{K,V}
     index::Dict{K, Int}
 
     function PriorityQueue(o::O)
-        new(Array{Pair{K,V}}(0), o, Dict{K, Int}())
+        new(Vector{Pair{K,V}}(0), o, Dict{K, Int}())
     end
 
     PriorityQueue() = PriorityQueue{K,V,O}(Forward)
@@ -47,7 +47,7 @@ type PriorityQueue{K,V,O<:Ordering} <: Associative{K,V}
     end
 
     function PriorityQueue(itr, o::O)
-        xs = Array{Pair{K,V}}(length(itr))
+        xs = Vector{Pair{K,V}}(length(itr))
         index = Dict{K, Int}()
         for (i, (k, v)) in enumerate(itr)
             xs[i] = Pair{K,V}(k, v)

--- a/test/test_mutable_binheap.jl
+++ b/test/test_mutable_binheap.jl
@@ -6,7 +6,7 @@ function heap_values{VT,Comp}(h::MutableBinaryHeap{VT,Comp})
     n = length(h)
     nodes = h.nodes
     @assert length(nodes) == n
-    vs = Array(VT, n)
+    vs = Vector{VT}(n)
     for i = 1 : n
         vs[i] = nodes[i].value
     end
@@ -17,7 +17,7 @@ function list_values{VT,Comp}(h::MutableBinaryHeap{VT,Comp})
     n = length(h)
     nodes = h.nodes
     nodemap = h.node_map
-    vs = Array(VT, 0)
+    vs = Vector{VT}(0)
     for i = 1 : length(nodemap)
         id = nodemap[i]
         if id > 0

--- a/test/test_priorityqueue.jl
+++ b/test/test_priorityqueue.jl
@@ -100,7 +100,7 @@ xs = heapify!([v for v in values(priorities)])
 xs = heapify(10:-1:1)
 @test issorted([heappop!(xs) for _ in 1:10])
 
-xs = Array{Int,1}(0)
+xs = Vector{Int}(0)
 for priority in values(priorities)
     heappush!(xs, priority)
 end

--- a/test/test_sorted_containers.jl
+++ b/test/test_sorted_containers.jl
@@ -86,10 +86,10 @@ function checkcorrectness{K,D,Ord <: Ordering}(t::DataStructures.BalancedTree23{
     dsz = size(t.data, 1)
     tsz = size(t.tree, 1)
     r = t.rootloc
-    bfstreenodes = Array(Int, 0)
+    bfstreenodes = Vector{Int}(0)
     tdpth = t.depth
     intree = IntSet()
-    levstart = Array(Int, tdpth)
+    levstart = Vector{Int}(tdpth)
     push!(bfstreenodes, r)
     levstart[1] = 1
     push!(intree, r)
@@ -122,8 +122,8 @@ function checkcorrectness{K,D,Ord <: Ordering}(t::DataStructures.BalancedTree23{
     end
     bfstreesize = size(bfstreenodes, 1)
     dataused = IntSet()
-    minkeys = Array(K, bfstreesize)
-    maxkeys = Array(K, bfstreesize)
+    minkeys = Vector{K}(bfstreesize)
+    maxkeys = Vector{K}(bfstreesize)
     for s = levstart[tdpth] : bfstreesize
         anc = bfstreenodes[s]
         c1 = t.tree[anc].child1


### PR DESCRIPTION
Is there a better way to handle the new `where` syntax than `eval(parse(...))`?