### PR TITLE
RFC: Remove eval from DefaultDict constructor

### DIFF
--- a/src/default_dict.jl
+++ b/src/default_dict.jl
@@ -14,38 +14,20 @@
 # subclassed.
 #
 
-_oldDefaultDictBase = """
 immutable DefaultDictBase{K,V,F,D} <: Associative{K,V}
     default::F
     d::D
 
     check_D(D,K,V) = (D <: Associative{K,V}) ||
-        throw(ArgumentError("Default dict must be <: Associative{K,V}"))
+        throw(ArgumentError("Default dict must be <: Associative{$K,$V}"))
 
     DefaultDictBase(x::F, kv::AbstractArray{Tuple{K,V}}) = (check_D(D,K,V); new(x, D(kv)))
     DefaultDictBase(x::F, ps::Pair{K,V}...) = (check_D(D,K,V); new(x, D(ps...)))
 
-    DefaultDictBase(x::F, d::DefaultDictBase) = (check_D(D,K,V); DefaultDictBase(x, d.d))
-    DefaultDictBase(x::F, d::D=D()) = (check_D(D,K,V); new(x, d))
-end
-"""
-
-_newDefaultDictBase = """
-immutable DefaultDictBase{K,V,F,D} <: Associative{K,V}
-    default::F
-    d::D
-
-    check_D(D,K,V) = (D <: Associative{K,V}) ||
-        throw(ArgumentError("Default dict must be <: Associative{K,V}"))
-
-    DefaultDictBase(x::F, kv::AbstractArray{Tuple{K,V}}) = (check_D(D,K,V); new(x, D(kv)))
-    DefaultDictBase(x::F, ps::Pair{K,V}...) = (check_D(D,K,V); new(x, D(ps...)))
-    (::Type{DefaultDictBase{K,V,F,D}}){K,V,F,D<:DefaultDictBase}(x::F, d::D) =
+    @compat (::Type{DefaultDictBase{K,V,F,D}}){K,V,F,D<:DefaultDictBase}(x::F, d::D) =
         (check_D(D,K,V); DefaultDictBase(x, d.d))
     DefaultDictBase(x::F, d::D = D()) = (check_D(D,K,V); new(x, d))
 end
-"""
-eval(VERSION < v"0.6.0-dev.2123" ? parse(_oldDefaultDictBase) : parse(_newDefaultDictBase))
 
 # Constructors
 


### PR DESCRIPTION
* eval was being used to create the `DefaultDict` type, because it required some v0.6 specific changes.  
  However, with `@compat`, eval isn't needed (unless I missed something?)

(The actual change to the constructor itself is needed, though!)

Cc: @andreasnoack 