### PR TITLE
Fix typing in Binary Heap

### DIFF
--- a/src/heaps/binary_heap.jl
+++ b/src/heaps/binary_heap.jl
@@ -104,7 +104,7 @@ end
 
 type BinaryHeap{T,Comp} <: AbstractHeap{T}
     comparer::Comp
-    valtree::Array{T}
+    valtree::Vector{T}
 
     function BinaryHeap(comp::Comp)
         new(comp, Vector{T}(0))


### PR DESCRIPTION
The `valtree` in the binary heap is not strictly typed. In some codes I have, this causes a 2x performance reduction in the entire code (<.1% is data structure related) due to checking if a binary heap is empty. The simple fix is to make it `Vector{T}` instead of the non-concerete `Array{T}`.

Reference for performance problems: https://github.com/JuliaDiffEq/StochasticDiffEq.jl/issues/13